### PR TITLE
Always consume response before dispatching

### DIFF
--- a/src/main/java/org/zalando/riptide/BufferingClientHttpResponseWrapper.java
+++ b/src/main/java/org/zalando/riptide/BufferingClientHttpResponseWrapper.java
@@ -1,0 +1,85 @@
+package org.zalando.riptide;
+
+/*
+ * ⁣​
+ * Riptide
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StreamUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+final class BufferingClientHttpResponseWrapper implements ClientHttpResponse {
+
+    static BufferingClientHttpResponseWrapper buffer(ClientHttpResponse response) throws IOException {
+        final BufferingClientHttpResponseWrapper wrapper = new BufferingClientHttpResponseWrapper(response);
+        wrapper.buffer();
+        return wrapper;
+    }
+
+    private final ClientHttpResponse response;
+
+    private byte[] body;
+
+    private BufferingClientHttpResponseWrapper(ClientHttpResponse response) {
+        this.response = response;
+    }
+
+
+    @Override
+    public HttpStatus getStatusCode() throws IOException {
+        return response.getStatusCode();
+    }
+
+    @Override
+    public int getRawStatusCode() throws IOException {
+        return response.getRawStatusCode();
+    }
+
+    @Override
+    public String getStatusText() throws IOException {
+        return response.getStatusText();
+    }
+
+    @Override
+    public HttpHeaders getHeaders() {
+        return response.getHeaders();
+    }
+
+    @Override
+    public InputStream getBody() throws IOException {
+        return body == null ? null : new ByteArrayInputStream(body);
+    }
+
+    @Override
+    public void close() {
+        response.close();
+    }
+
+    private void buffer() throws IOException {
+        if (response.getBody() != null) {
+            body = StreamUtils.copyToByteArray(response.getBody());
+        }
+    }
+
+}

--- a/src/main/java/org/zalando/riptide/OAuth2CompatibilityResponseErrorHandler.java
+++ b/src/main/java/org/zalando/riptide/OAuth2CompatibilityResponseErrorHandler.java
@@ -56,7 +56,7 @@ public final class OAuth2CompatibilityResponseErrorHandler implements ResponseEr
 
     @Override
     public void handleError(ClientHttpResponse response) throws IOException {
-        throw new AlreadyConsumedResponseException(response);
+        throw new AlreadyConsumedResponseException(BufferingClientHttpResponseWrapper.buffer(response));
     }
 
 }

--- a/src/main/java/org/zalando/riptide/Rest.java
+++ b/src/main/java/org/zalando/riptide/Rest.java
@@ -23,9 +23,14 @@ package org.zalando.riptide;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 
 public final class Rest {
@@ -67,7 +72,7 @@ public final class Rest {
      */
     private <T> ClientHttpResponse execute(final HttpMethod method, final URI url, final Callback<T> callback) {
         try {
-            return template.execute(url, method, callback, r -> r);
+            return template.execute(url, method, callback, BufferingClientHttpResponseWrapper::buffer);
         } catch (AlreadyConsumedResponseException e) {
             return e.getResponse();
         }

--- a/src/test/java/org/example/application/ApiIntegrationTest.java
+++ b/src/test/java/org/example/application/ApiIntegrationTest.java
@@ -93,27 +93,27 @@ public class ApiIntegrationTest {
         server.expect(requestTo(url)).andRespond(withSuccess());
 
         unit.execute(GET, url)
-            .dispatch(series(),
-                    on(SUCCESSFUL)
-                            .dispatch(status(),
-                                    on(CREATED, Success.class).capture(),
-                                    on(ACCEPTED, Success.class).capture(),
-                                    anyStatus().call(this::callback)),
-                    on(CLIENT_ERROR)
-                            .dispatch(status(),
-                                    on(UNAUTHORIZED).call(this::callback),
-                                    on(UNPROCESSABLE_ENTITY)
-                                            .dispatch(contentType(),
-                                                    on(PROBLEM, Problem.class).capture(),
-                                                    on(ERROR, Problem.class).capture(),
-                                                    anyContentType().call(this::callback)),
-                                    anyStatus().call(this::callback)),
-                    on(SERVER_ERROR)
-                            .dispatch(statusCode(),
-                                    on(503).call(this::callback),
-                                    anyStatusCode().call(this::callback)),
-                    anySeries().call(this::callback))
-            .retrieve(Success.class).orElse(null);
+                .dispatch(series(),
+                        on(SUCCESSFUL)
+                                .dispatch(status(),
+                                        on(CREATED, Success.class).capture(),
+                                        on(ACCEPTED, Success.class).capture(),
+                                        anyStatus().call(this::callback)),
+                        on(CLIENT_ERROR)
+                                .dispatch(status(),
+                                        on(UNAUTHORIZED).call(this::callback),
+                                        on(UNPROCESSABLE_ENTITY)
+                                                .dispatch(contentType(),
+                                                        on(PROBLEM, Problem.class).capture(),
+                                                        on(ERROR, Problem.class).capture(),
+                                                        anyContentType().call(this::callback)),
+                                        anyStatus().call(this::callback)),
+                        on(SERVER_ERROR)
+                                .dispatch(statusCode(),
+                                        on(503).call(this::callback),
+                                        anyStatusCode().call(this::callback)),
+                        anySeries().call(this::callback))
+                .retrieve(Success.class).orElse(null);
     }
 
     private void callback(final ClientHttpResponse response) {

--- a/src/test/java/org/example/application/RestIntegrationTest.java
+++ b/src/test/java/org/example/application/RestIntegrationTest.java
@@ -1,0 +1,157 @@
+package org.example.application;
+
+/*
+ * ⁣​
+ * riptide
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.riptide.OAuth2CompatibilityResponseErrorHandler;
+import org.zalando.riptide.PassThroughResponseErrorHandler;
+import org.zalando.riptide.Rest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.zalando.riptide.Conditions.anyStatus;
+import static org.zalando.riptide.Conditions.on;
+import static org.zalando.riptide.Selectors.status;
+
+/**
+ * Simple sanity check to see if the API of riptide is actually public and accessible.
+ */
+public class RestIntegrationTest {
+
+    private final URI url = URI.create("http://localhost");
+
+    private MockRestServiceServer server;
+    private Rest unit;
+
+    private void setUp(final ResponseErrorHandler errorHandler) {
+        final RestTemplate template = new RestTemplate();
+        final MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(new ObjectMapper().findAndRegisterModules());
+        template.setMessageConverters(singletonList(converter));
+        template.setErrorHandler(errorHandler);
+
+        this.server = MockRestServiceServer.createServer(template);
+        this.unit = Rest.create(template);
+    }
+
+    @Test
+    public void shouldNotConsumeMyResponse() throws IOException {
+        setUp(new PassThroughResponseErrorHandler());
+
+        server.expect(requestTo(url)).andRespond(this::onetimeConsumableResponse);
+
+        final Map map = unit.execute(GET, url).dispatch(status(),
+                on(OK, Map.class).capture(),
+                anyStatus().call(this::error))
+                .retrieve(Map.class).get();
+
+        assertThat(map, is(emptyMap()));
+    }
+
+    @Test
+    public void shouldNotConsumeMyResponseWithOAuth2CompatibilityHandler() throws IOException {
+        setUp(new ResponseErrorHandler() {
+            @Override
+            public boolean hasError(ClientHttpResponse response) throws IOException {
+                return true;
+            }
+
+            @Override
+            public void handleError(ClientHttpResponse response) throws IOException {
+                new OAuth2CompatibilityResponseErrorHandler().handleError(response);
+            }
+        });
+
+        server.expect(requestTo(url)).andRespond(this::onetimeConsumableResponse);
+
+        final Map map = unit.execute(GET, url).dispatch(status(),
+                on(OK, Map.class).capture(),
+                anyStatus().call(this::error))
+                .retrieve(Map.class).get();
+
+        assertThat(map, is(emptyMap()));
+    }
+
+    private void error(final ClientHttpResponse response) {
+        throw new AssertionError("Should not have been called");
+    }
+
+    private ClientHttpResponse onetimeConsumableResponse(final ClientHttpRequest request) throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        when(response.getStatusCode()).thenReturn(HttpStatus.OK);
+        when(response.getStatusText()).thenReturn(HttpStatus.OK.getReasonPhrase());
+        when(response.getHeaders()).thenReturn(headers);
+        when(response.getBody()).thenReturn(new InputStream() {
+            private boolean closed = false;
+
+            private ByteArrayInputStream bytes = new ByteArrayInputStream("{}".getBytes());
+
+            @Override
+            public int read() throws IOException {
+                if (closed) {
+                    throw new IOException("Already closed");
+                }
+                return bytes.read();
+            }
+
+            @Override
+            public void close() throws IOException {
+                if (closed) {
+                    throw new IOException("Already closed");
+                }
+                closed = true;
+            }
+        });
+        doAnswer(invocationOnMock -> {
+            ((ClientHttpResponse) invocationOnMock.getMock()).getBody().close();
+            return null;
+        }).when(response).close();
+        return response;
+    }
+
+}

--- a/src/test/java/org/zalando/riptide/BufferingClientHttpResponseWrapperTest.java
+++ b/src/test/java/org/zalando/riptide/BufferingClientHttpResponseWrapperTest.java
@@ -1,0 +1,87 @@
+package org.zalando.riptide;
+
+/*
+ * ⁣​
+ * Riptide
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import com.google.common.io.ByteStreams;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BufferingClientHttpResponseWrapperTest {
+
+    private final ClientHttpResponse response = mock(ClientHttpResponse.class);
+
+    private BufferingClientHttpResponseWrapper unit;
+
+    @Test
+    public void buffersBody() throws IOException {
+        final byte[] data = {0x13, 0x37};
+        when(response.getBody()).thenReturn(new ByteArrayInputStream(data));
+
+        unit = BufferingClientHttpResponseWrapper.buffer(response);
+
+        assertThat(ByteStreams.toByteArray(unit.getBody()), is(data));
+    }
+
+    @Test
+    public void skipsBodyIfNull() throws IOException {
+        when(response.getBody()).thenReturn(null);
+
+        unit = BufferingClientHttpResponseWrapper.buffer(response);
+
+        assertThat(unit.getBody(), is(nullValue()));
+    }
+
+    @Test
+    public void closesResponse() throws IOException {
+        unit = BufferingClientHttpResponseWrapper.buffer(response);
+
+        unit.close();
+
+        verify(response).close();
+    }
+
+    @Test
+    public void redirectsStatusFields() throws IOException {
+        when(response.getStatusCode()).thenReturn(HttpStatus.ACCEPTED);
+        when(response.getStatusText()).thenReturn("status-text");
+        when(response.getRawStatusCode()).thenReturn(42);
+        when(response.getHeaders()).thenReturn(new HttpHeaders());
+
+        unit = BufferingClientHttpResponseWrapper.buffer(response);
+
+        assertThat(unit.getStatusCode(), is(response.getStatusCode()));
+        assertThat(unit.getStatusText(), is(response.getStatusText()));
+        assertThat(unit.getRawStatusCode(), is(response.getRawStatusCode()));
+        assertThat(unit.getHeaders(), is(response.getHeaders()));
+    }
+}


### PR DESCRIPTION
We have to always consume and buffer the response before dispatching
since RestTemplate will close the stream after executing the request.

The only chance to buffer is therefore in the ResponseExtractor.