### PR TITLE
Store Type-Information on Capture

### DIFF
--- a/src/main/java/org/zalando/riptide/Binding.java
+++ b/src/main/java/org/zalando/riptide/Binding.java
@@ -42,7 +42,7 @@ public final class Binding<A> implements Executor {
     }
 
     @Override
-    public Object execute(ClientHttpResponse response, List<HttpMessageConverter<?>> converters) throws IOException {
+    public Captured execute(ClientHttpResponse response, List<HttpMessageConverter<?>> converters) throws IOException {
         return executor.execute(response, converters);
     }
     

--- a/src/main/java/org/zalando/riptide/Captured.java
+++ b/src/main/java/org/zalando/riptide/Captured.java
@@ -1,0 +1,58 @@
+package org.zalando.riptide;
+
+/*
+ * ⁣​
+ * Riptide
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import com.google.common.reflect.TypeToken;
+
+import javax.annotation.Nullable;
+
+class Captured {
+
+    public static Captured wrap(@Nullable final Object value, final TypeToken<?> type) {
+        return new TypedCaptured(value, type);
+    }
+
+    public static Captured wrap(@Nullable final Object value, final Class<?> type) {
+        return wrap(value, TypeToken.of(type));
+    }
+
+    public static Captured wrap(@Nullable final Object value) {
+        return new Captured(value);
+    }
+
+    public static Captured wrapNothing() {
+        return wrap(null);
+    }
+
+    private final Object value;
+
+    Captured(@Nullable final Object value) {
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public boolean isAssignableTo(final TypeToken<?> otherType) {
+        return value != null && otherType.isAssignableFrom(value.getClass());
+    }
+}

--- a/src/main/java/org/zalando/riptide/Dispatcher.java
+++ b/src/main/java/org/zalando/riptide/Dispatcher.java
@@ -45,11 +45,11 @@ public final class Dispatcher {
     public final <A> Retriever dispatch(Selector<A> selector, Binding<A>... bindings)
             throws UnsupportedResponseException {
         final List<HttpMessageConverter<?>> converters = template.getMessageConverters();
-        final Object value = route(selector, converters, bindings);
+        final Captured value = route(selector, converters, bindings);
         return new Retriever(value);
     }
 
-    private <A> Object route(Selector<A> selector, List<HttpMessageConverter<?>> converters, Binding<A>[] bindings) {
+    private <A> Captured route(Selector<A> selector, List<HttpMessageConverter<?>> converters, Binding<A>[] bindings) {
         try {
             return router.route(response, converters, selector, asList(bindings));
         } catch (IOException e) {

--- a/src/main/java/org/zalando/riptide/Retriever.java
+++ b/src/main/java/org/zalando/riptide/Retriever.java
@@ -23,39 +23,46 @@ package org.zalando.riptide;
 import com.google.common.reflect.TypeToken;
 import org.springframework.http.client.ClientHttpResponse;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 
 public final class Retriever {
-    
-    private final Object value;
 
-    public Retriever(@Nullable Object value) {
-        this.value = value;
+    private final Captured captured;
+
+    public Retriever(final Captured captured) {
+        this.captured = captured;
     }
 
-    public <T> Optional<T> retrieve(Class<T> type) {
+    public <T> Optional<T> retrieve(final Class<T> type) {
         return retrieve(TypeToken.of(type));
     }
 
-    public <T> Optional<T> retrieve(TypeToken<T> type) {
-        return Optional.ofNullable(value)
-                .filter(v -> type.isAssignableFrom(v.getClass()))
+    public <T> Optional<T> retrieve(final TypeToken<?> type) {
+        return Optional.ofNullable(captured.getValue())
+                .filter(v -> this.hasRetrieved(type))
                 .map(v -> {
-                    @SuppressWarnings("unchecked") 
+                    @SuppressWarnings("unchecked")
                     final T t = (T) v;
                     return t;
                 });
     }
-    
+
     /**
      * Convenience method for {@code retrieve(ClientHttpResponse.class)}.
-     * 
+     *
      * @return optional response, present only if successfully captured
-     * @see #retrieve(Class) 
+     * @see #retrieve(Class)
      */
     public Optional<ClientHttpResponse> retrieveResponse() {
         return retrieve(ClientHttpResponse.class);
+    }
+
+    public boolean hasRetrieved(final Class<?> type) {
+        return hasRetrieved(TypeToken.of(type));
+    }
+
+    public boolean hasRetrieved(final TypeToken<?> type) {
+        return captured.isAssignableTo(type);
     }
 
 }

--- a/src/main/java/org/zalando/riptide/Router.java
+++ b/src/main/java/org/zalando/riptide/Router.java
@@ -40,7 +40,7 @@ final class Router {
 
     private static final Optional ANY = Optional.empty();
 
-    final <A> Object route(ClientHttpResponse response, List<HttpMessageConverter<?>> converters,
+    final <A> Captured route(ClientHttpResponse response, List<HttpMessageConverter<?>> converters,
             Selector<A> selector, Collection<Binding<A>> bindings) throws IOException {
 
         final Optional<A> attribute = selector.attributeOf(response);
@@ -71,7 +71,7 @@ final class Router {
         throw new IllegalStateException("Duplicate any conditions");
     }
 
-    private <A> Object propagateNoMatch(ClientHttpResponse response, List<HttpMessageConverter<?>> converters, 
+    private <A> Captured propagateNoMatch(ClientHttpResponse response, List<HttpMessageConverter<?>> converters,
             Optional<A> attribute, Map<Optional<A>, Binding<A>> index, UnsupportedResponseException e) throws IOException {
         try {
             return routeNone(response, converters, attribute, index);
@@ -81,7 +81,7 @@ final class Router {
         }
     }
 
-    private <A> Object routeNone(ClientHttpResponse response, List<HttpMessageConverter<?>> converters,
+    private <A> Captured routeNone(ClientHttpResponse response, List<HttpMessageConverter<?>> converters,
             Optional<A> attribute, Map<Optional<A>, Binding<A>> index)
             throws IOException {
 

--- a/src/main/java/org/zalando/riptide/TypedCaptured.java
+++ b/src/main/java/org/zalando/riptide/TypedCaptured.java
@@ -2,7 +2,7 @@ package org.zalando.riptide;
 
 /*
  * ⁣​
- * riptide
+ * Riptide
  * ⁣⁣
  * Copyright (C) 2015 Zalando SE
  * ⁣⁣
@@ -20,15 +20,25 @@ package org.zalando.riptide;
  * ​⁣
  */
 
-import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.http.converter.HttpMessageConverter;
+import com.google.common.reflect.TypeToken;
 
-import java.io.IOException;
-import java.util.List;
+import javax.annotation.Nullable;
 
-@FunctionalInterface
-interface Executor {
+class TypedCaptured extends Captured {
 
-    Captured execute(ClientHttpResponse response, List<HttpMessageConverter<?>> converters) throws IOException;
+    private final TypeToken<?> type;
 
+    TypedCaptured(@Nullable final Object value, final TypeToken<?> type) {
+        super(value);
+        this.type = type;
+    }
+
+    public TypeToken<?> getType() {
+        return type;
+    }
+
+    @Override
+    public boolean isAssignableTo(final TypeToken<?> otherType) {
+        return otherType.isAssignableFrom(getType());
+    }
 }

--- a/src/main/java/org/zalando/riptide/TypedCondition.java
+++ b/src/main/java/org/zalando/riptide/TypedCondition.java
@@ -79,6 +79,10 @@ public final class TypedCondition<A, I> implements Capturer<A> {
         });
     }
 
+    public <T> Capturer<A> map(EntityFunction<I, T> function, Class<T> mappedType) {
+        return map(function, TypeToken.of(mappedType));
+    }
+
     public <T> Capturer<A> map(EntityFunction<I, T> function, TypeToken<T> mappedType) {
         return () -> Binding.create(attribute, (response, converters) -> {
             final I entity = convert(response, converters);
@@ -91,6 +95,10 @@ public final class TypedCondition<A, I> implements Capturer<A> {
             final I entity = convert(response, converters);
             return wrap(function.apply(toResponseEntity(entity, response)));
         });
+    }
+
+    public <T> Capturer<A> map(ResponseEntityFunction<I, T> function, Class<T> mappedType) {
+        return map(function, TypeToken.of(mappedType));
     }
 
     public <T> Capturer<A> map(ResponseEntityFunction<I, T> function, TypeToken<T> mappedType) {

--- a/src/main/java/org/zalando/riptide/TypedCondition.java
+++ b/src/main/java/org/zalando/riptide/TypedCondition.java
@@ -31,6 +31,9 @@ import org.springframework.web.client.RestClientException;
 import java.io.IOException;
 import java.util.List;
 
+import static org.zalando.riptide.Captured.wrap;
+import static org.zalando.riptide.Captured.wrapNothing;
+
 public final class TypedCondition<A, I> implements Capturer<A> {
 
     private final A attribute;
@@ -57,7 +60,7 @@ public final class TypedCondition<A, I> implements Capturer<A> {
         return Binding.create(attribute, (response, converters) -> {
             final I entity = convert(response, converters);
             consumer.accept(entity);
-            return null;
+            return wrapNothing();
         });
     }
 
@@ -65,27 +68,41 @@ public final class TypedCondition<A, I> implements Capturer<A> {
         return Binding.create(attribute, (response, converters) -> {
             final I entity = convert(response, converters);
             consumer.accept(toResponseEntity(entity, response));
-            return null;
+            return wrapNothing();
         });
     }
 
     public Capturer<A> map(EntityFunction<I, ?> function) {
         return () -> Binding.create(attribute, (response, converters) -> {
             final I entity = convert(response, converters);
-            return function.apply(entity);
+            return wrap(function.apply(entity));
+        });
+    }
+
+    public <T> Capturer<A> map(EntityFunction<I, T> function, TypeToken<T> mappedType) {
+        return () -> Binding.create(attribute, (response, converters) -> {
+            final I entity = convert(response, converters);
+            return wrap(function.apply(entity), mappedType);
         });
     }
 
     public Capturer<A> map(ResponseEntityFunction<I, ?> function) {
         return () -> Binding.create(attribute, (response, converters) -> {
             final I entity = convert(response, converters);
-            return function.apply(toResponseEntity(entity, response));
+            return wrap(function.apply(toResponseEntity(entity, response)));
+        });
+    }
+
+    public <T> Capturer<A> map(ResponseEntityFunction<I, T> function, TypeToken<T> mappedType) {
+        return () -> Binding.create(attribute, (response, converters) -> {
+            final I entity = convert(response, converters);
+            return wrap(function.apply(toResponseEntity(entity, response)), mappedType);
         });
     }
 
     @Override
     public Binding<A> capture() {
-        return Binding.create(attribute, this::convert);
+        return Binding.create(attribute, ((response, converters) -> wrap(convert(response, converters), type)));
     }
 
 }

--- a/src/main/java/org/zalando/riptide/UntypedCondition.java
+++ b/src/main/java/org/zalando/riptide/UntypedCondition.java
@@ -20,12 +20,15 @@ package org.zalando.riptide;
  * ​⁣
  */
 
+import com.google.common.reflect.TypeToken;
 import org.springframework.http.client.ClientHttpResponse;
 
 import java.io.IOException;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
+import static org.zalando.riptide.Captured.wrap;
+import static org.zalando.riptide.Captured.wrapNothing;
 
 public final class UntypedCondition<A> {
 
@@ -39,16 +42,20 @@ public final class UntypedCondition<A> {
     public Binding<A> call(ThrowingConsumer<ClientHttpResponse, IOException> consumer) {
         return Binding.create(attribute, (response, converters) -> {
             consumer.accept(response);
-            return null;
+            return wrapNothing();
         });
     }
 
     public Capturer<A> map(ThrowingFunction<ClientHttpResponse, ?, IOException> function) {
-        return () -> Binding.create(attribute, (response, converters) -> function.apply(response));
+        return () -> Binding.create(attribute, (response, converters) -> wrap(function.apply(response)));
+    }
+
+    public <T> Capturer<A> map(ThrowingFunction<ClientHttpResponse, ?, IOException> function, TypeToken<T> mappedType) {
+        return () -> Binding.create(attribute, (response, converters) -> wrap(function.apply(response), mappedType));
     }
 
     public Binding<A> capture() {
-        return Binding.create(attribute, (response, converters) -> response);
+        return Binding.create(attribute, (response, converters) -> wrap(response, ClientHttpResponse.class));
     }
 
     @SafeVarargs

--- a/src/main/java/org/zalando/riptide/UntypedCondition.java
+++ b/src/main/java/org/zalando/riptide/UntypedCondition.java
@@ -50,6 +50,10 @@ public final class UntypedCondition<A> {
         return () -> Binding.create(attribute, (response, converters) -> wrap(function.apply(response)));
     }
 
+    public <T> Capturer<A> map(ThrowingFunction<ClientHttpResponse, ?, IOException> function, Class<T> mappedType) {
+        return map(function, TypeToken.of(mappedType));
+    }
+
     public <T> Capturer<A> map(ThrowingFunction<ClientHttpResponse, ?, IOException> function, TypeToken<T> mappedType) {
         return () -> Binding.create(attribute, (response, converters) -> wrap(function.apply(response), mappedType));
     }

--- a/src/test/java/org/example/application/OneTimeConsumableResponse.java
+++ b/src/test/java/org/example/application/OneTimeConsumableResponse.java
@@ -1,0 +1,97 @@
+package org.example.application;
+
+/*
+ * ⁣​
+ * Riptide
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+class OneTimeConsumableResponse implements ClientHttpResponse {
+
+    private boolean closed = false;
+
+    private final String bodyContent;
+
+    OneTimeConsumableResponse(String bodyContent) {
+        this.bodyContent = bodyContent;
+    }
+
+    @Override
+    public HttpHeaders getHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        return headers;
+    }
+
+    @Override
+    public HttpStatus getStatusCode() throws IOException {
+        return HttpStatus.OK;
+    }
+
+    @Override
+    public int getRawStatusCode() throws IOException {
+        return getStatusCode().value();
+    }
+
+    @Override
+    public String getStatusText() throws IOException {
+        return getStatusCode().getReasonPhrase();
+    }
+
+    @Override
+    public void close() {
+        try {
+            getBody().close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public InputStream getBody() throws IOException {
+        return new InputStream() {
+            private boolean closed = false;
+
+            private ByteArrayInputStream bytes = new ByteArrayInputStream(bodyContent.getBytes());
+
+            @Override
+            public int read() throws IOException {
+                if (closed) {
+                    throw new IOException("Already closed");
+                }
+                return bytes.read();
+            }
+
+            @Override
+            public void close() throws IOException {
+                if (closed) {
+                    throw new IOException("Already closed");
+                }
+                closed = true;
+            }
+        };
+    }
+}

--- a/src/test/java/org/zalando/riptide/MapTest.java
+++ b/src/test/java/org/zalando/riptide/MapTest.java
@@ -65,7 +65,7 @@ public final class MapTest {
         this.server = MockRestServiceServer.createServer(template);
         this.unit = Rest.create(template);
     }
-    
+
     @Test
     public void shouldMapResponse() {
         server.expect(requestTo(url)).andRespond(
@@ -78,14 +78,14 @@ public final class MapTest {
                         on(OK).map(this::fromResponse).capture(),
                         anyStatus().call(this::fail))
                 .retrieve(Account.class).get();
-        
+
         assertThat(account.getId(), is("1234567890"));
         assertThat(account.getRevision(), is("fake"));
         assertThat(account.getName(), is("Acme Corporation"));
     }
 
     private Account fromResponse(ClientHttpResponse response) throws IOException {
-        final AccountBody account = new HttpMessageConverterExtractor<>(AccountBody.class, 
+        final AccountBody account = new HttpMessageConverterExtractor<>(AccountBody.class,
                 template.getMessageConverters()).extractData(response);
         return new Account(account.getId(), "fake", account.getName());
     }
@@ -102,7 +102,7 @@ public final class MapTest {
                         on(OK, AccountBody.class).map(this::fromEntity).capture(),
                         anyStatus().call(this::fail))
                 .retrieve(Account.class).get();
-        
+
         assertThat(account.getId(), is("1234567890"));
         assertThat(account.getRevision(), is("fake"));
         assertThat(account.getName(), is("Acme Corporation"));
@@ -111,7 +111,7 @@ public final class MapTest {
     private Account fromEntity(AccountBody account) {
         return new Account(account.getId(), "fake", account.getName());
     }
-    
+
     @Test
     public void shouldMapResponseEntity() {
         final String revision = '"' + "1aa9520a-0cdd-11e5-aa27-8361dd72e660" + '"';

--- a/src/test/java/org/zalando/riptide/MapTest.java
+++ b/src/test/java/org/zalando/riptide/MapTest.java
@@ -84,6 +84,24 @@ public final class MapTest {
         assertThat(account.getName(), is("Acme Corporation"));
     }
 
+    @Test
+    public void shouldMapTypedResponse() {
+        server.expect(requestTo(url)).andRespond(
+                withSuccess()
+                        .body(new ClassPathResource("account.json"))
+                        .contentType(APPLICATION_JSON));
+
+        final Account account = unit.execute(GET, url)
+                .dispatch(status(),
+                        on(OK).map(this::fromResponse, Account.class).capture(),
+                        anyStatus().call(this::fail))
+                .retrieve(Account.class).get();
+
+        assertThat(account.getId(), is("1234567890"));
+        assertThat(account.getRevision(), is("fake"));
+        assertThat(account.getName(), is("Acme Corporation"));
+    }
+
     private Account fromResponse(ClientHttpResponse response) throws IOException {
         final AccountBody account = new HttpMessageConverterExtractor<>(AccountBody.class,
                 template.getMessageConverters()).extractData(response);
@@ -100,6 +118,24 @@ public final class MapTest {
         final Account account = unit.execute(GET, url)
                 .dispatch(status(),
                         on(OK, AccountBody.class).map(this::fromEntity).capture(),
+                        anyStatus().call(this::fail))
+                .retrieve(Account.class).get();
+
+        assertThat(account.getId(), is("1234567890"));
+        assertThat(account.getRevision(), is("fake"));
+        assertThat(account.getName(), is("Acme Corporation"));
+    }
+
+    @Test
+    public void shouldMapTypedEntity() {
+        server.expect(requestTo(url)).andRespond(
+                withSuccess()
+                        .body(new ClassPathResource("account.json"))
+                        .contentType(APPLICATION_JSON));
+
+        final Account account = unit.execute(GET, url)
+                .dispatch(status(),
+                        on(OK, AccountBody.class).map(this::fromEntity, Account.class).capture(),
                         anyStatus().call(this::fail))
                 .retrieve(Account.class).get();
 
@@ -128,6 +164,30 @@ public final class MapTest {
         final Account account = unit.execute(GET, url)
                 .dispatch(status(),
                         on(OK, AccountBody.class).map(this::fromResponseEntity).capture(),
+                        anyStatus().call(this::fail))
+                .retrieve(Account.class).get();
+
+        assertThat(account.getId(), is("1234567890"));
+        assertThat(account.getRevision(), is(revision));
+        assertThat(account.getName(), is("Acme Corporation"));
+    }
+
+    @Test
+    public void shouldMapTypedResponseEntity() {
+        final String revision = '"' + "1aa9520a-0cdd-11e5-aa27-8361dd72e660" + '"';
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setETag(revision);
+
+        server.expect(requestTo(url)).andRespond(
+                withSuccess()
+                        .body(new ClassPathResource("account.json"))
+                        .contentType(APPLICATION_JSON)
+                        .headers(headers));
+
+        final Account account = unit.execute(GET, url)
+                .dispatch(status(),
+                        on(OK, AccountBody.class).map(this::fromResponseEntity, Account.class).capture(),
                         anyStatus().call(this::fail))
                 .retrieve(Account.class).get();
 

--- a/src/test/java/org/zalando/riptide/RetrieverTest.java
+++ b/src/test/java/org/zalando/riptide/RetrieverTest.java
@@ -1,0 +1,88 @@
+package org.zalando.riptide;
+
+/*
+ * ⁣​
+ * Riptide
+ * ⁣⁣
+ * Copyright (C) 2015 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+import com.google.common.reflect.TypeToken;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class RetrieverTest {
+
+    @Test
+    public void shouldNotRetrieveNullOnCaptured() {
+        final Captured value = new Captured(null);
+
+        final Retriever unit = new Retriever(value);
+
+        assertThat(unit.hasRetrieved(String.class), is(false));
+        assertThat(unit.retrieve(String.class), is(Optional.empty()));
+    }
+
+    @Test
+    public void shouldRetrieveNullOnTypedCaptured() {
+        final Captured value = new TypedCaptured(null, TypeToken.of(String.class));
+
+        final Retriever unit = new Retriever(value);
+
+        assertThat(unit.hasRetrieved(String.class), is(true));
+        assertThat(unit.retrieve(String.class), is(Optional.empty()));
+    }
+
+    @Test
+    public void shouldRetrieveCaptured() {
+        final Captured value = new Captured("");
+
+        final Retriever unit = new Retriever(value);
+
+        assertThat(unit.hasRetrieved(String.class), is(true));
+        assertThat(unit.retrieve(String.class), is(not(Optional.empty())));
+    }
+
+    @Test
+    public void shouldNotRetrieveCapturedOnParameterizedType() {
+        TypeToken<List<String>> type = new TypeToken<List<String>>() {};
+        final Captured value = new Captured(newArrayList());
+
+        final Retriever unit = new Retriever(value);
+
+        assertThat(unit.hasRetrieved(type), is(false));
+        assertThat(unit.retrieve(type), is(Optional.empty()));
+    }
+
+    @Test
+    public void shouldRetrieveTypedCaptured() {
+        TypeToken<List<String>> type = new TypeToken<List<String>>() {};
+        final Captured value = new TypedCaptured(newArrayList(), type);
+
+        final Retriever unit = new Retriever(value);
+
+        assertThat(unit.hasRetrieved(type), is(true));
+        assertThat(unit.retrieve(type), is(not(Optional.empty())));
+    }
+
+}


### PR DESCRIPTION
Trying to resolve #26 .

Store type-information used to capture on a TypedCondition (or on
capturing a ClientHttpResponse) to allow same type to be used on
retrievale. This enabels clients to use parameterized TypeTokens on
Binding creation and in a Retriever.