### PR TITLE
Optional on typedcondition call

### DIFF
--- a/src/main/java/org/zalando/riptide/TypedCondition.java
+++ b/src/main/java/org/zalando/riptide/TypedCondition.java
@@ -57,7 +57,7 @@ public final class TypedCondition<A, I> implements Capturer<A> {
     public Binding<A> call(EntityConsumer<Optional<I>> consumer) {
         return Binding.create(attribute, (response, converters) -> {
             final I entity = convert(response, converters);
-            consumer.accept(Optional.of(entity));
+            consumer.accept(Optional.ofNullable(entity));
             return null;
         });
     }

--- a/src/main/java/org/zalando/riptide/TypedCondition.java
+++ b/src/main/java/org/zalando/riptide/TypedCondition.java
@@ -30,6 +30,7 @@ import org.springframework.web.client.RestClientException;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public final class TypedCondition<A, I> implements Capturer<A> {
 
@@ -53,10 +54,10 @@ public final class TypedCondition<A, I> implements Capturer<A> {
         return new ResponseEntity<>(entity, response.getHeaders(), response.getStatusCode());
     }
 
-    public Binding<A> call(EntityConsumer<I> consumer) {
+    public Binding<A> call(EntityConsumer<Optional<I>> consumer) {
         return Binding.create(attribute, (response, converters) -> {
             final I entity = convert(response, converters);
-            consumer.accept(entity);
+            consumer.accept(Optional.of(entity));
             return null;
         });
     }
@@ -69,10 +70,10 @@ public final class TypedCondition<A, I> implements Capturer<A> {
         });
     }
 
-    public Capturer<A> map(EntityFunction<I, ?> function) {
+    public Capturer<A> map(EntityFunction<Optional<I>, ?> function) {
         return () -> Binding.create(attribute, (response, converters) -> {
             final I entity = convert(response, converters);
-            return function.apply(entity);
+            return function.apply(Optional.ofNullable(entity));
         });
     }
 

--- a/src/test/java/org/zalando/riptide/CallTest.java
+++ b/src/test/java/org/zalando/riptide/CallTest.java
@@ -22,16 +22,19 @@ package org.zalando.riptide;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
+import org.zalando.riptide.model.Account;
 import org.zalando.riptide.model.AccountBody;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.any;
@@ -95,7 +98,7 @@ public final class CallTest {
                         .contentType(APPLICATION_JSON));
 
         @SuppressWarnings("unchecked")
-        final EntityConsumer<AccountBody> verifier = 
+        final EntityConsumer<Optional<AccountBody>> verifier =
                 mock(EntityConsumer.class);
 
         unit.execute(GET, url)
@@ -103,7 +106,7 @@ public final class CallTest {
                         on(OK, AccountBody.class).call(verifier),
                         anyStatus().call(this::fail));
 
-        verify(verifier).accept(any(AccountBody.class));
+        verify(verifier).accept(Matchers.<Optional<AccountBody>>any());
     }
     
     private void fail(ClientHttpResponse response) throws IOException {

--- a/src/test/java/org/zalando/riptide/MapTest.java
+++ b/src/test/java/org/zalando/riptide/MapTest.java
@@ -35,6 +35,7 @@ import org.zalando.riptide.model.AccountBody;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.is;
@@ -65,7 +66,7 @@ public final class MapTest {
         this.server = MockRestServiceServer.createServer(template);
         this.unit = Rest.create(template);
     }
-    
+
     @Test
     public void shouldMapResponse() {
         server.expect(requestTo(url)).andRespond(
@@ -78,14 +79,14 @@ public final class MapTest {
                         on(OK).map(this::fromResponse).capture(),
                         anyStatus().call(this::fail))
                 .retrieve(Account.class).get();
-        
+
         assertThat(account.getId(), is("1234567890"));
         assertThat(account.getRevision(), is("fake"));
         assertThat(account.getName(), is("Acme Corporation"));
     }
 
     private Account fromResponse(ClientHttpResponse response) throws IOException {
-        final AccountBody account = new HttpMessageConverterExtractor<>(AccountBody.class, 
+        final AccountBody account = new HttpMessageConverterExtractor<>(AccountBody.class,
                 template.getMessageConverters()).extractData(response);
         return new Account(account.getId(), "fake", account.getName());
     }
@@ -102,16 +103,16 @@ public final class MapTest {
                         on(OK, AccountBody.class).map(this::fromEntity).capture(),
                         anyStatus().call(this::fail))
                 .retrieve(Account.class).get();
-        
+
         assertThat(account.getId(), is("1234567890"));
         assertThat(account.getRevision(), is("fake"));
         assertThat(account.getName(), is("Acme Corporation"));
     }
 
-    private Account fromEntity(AccountBody account) {
-        return new Account(account.getId(), "fake", account.getName());
+    private Account fromEntity(Optional<AccountBody> account) {
+        return new Account(account.get().getId(), "fake", account.get().getName());
     }
-    
+
     @Test
     public void shouldMapResponseEntity() {
         final String revision = '"' + "1aa9520a-0cdd-11e5-aa27-8361dd72e660" + '"';


### PR DESCRIPTION
May resolve #25 

MessageConverters use *null* as a valid value on deserializing a type.
As we already wrap those values in an Optional for the *Receiver*
interface this commit adds this to the TypedCondition API.

This change breaks current API usages.