### PR TITLE
Changed message of NoRouteException

### DIFF
--- a/src/main/java/org/zalando/riptide/NoRouteException.java
+++ b/src/main/java/org/zalando/riptide/NoRouteException.java
@@ -23,6 +23,8 @@ package org.zalando.riptide;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestClientException;
 
+import java.io.IOException;
+
 /**
  * TODO javadoc
  */
@@ -30,9 +32,14 @@ public final class NoRouteException extends RestClientException {
 
     private final ClientHttpResponse response;
 
-    NoRouteException(final String message, final ClientHttpResponse response) {
-        super(message);
+    NoRouteException(final ClientHttpResponse response) throws IOException {
+        super(formatMessage(response));
         this.response = response;
+    }
+
+    private static String formatMessage(final ClientHttpResponse response) throws IOException {
+        return String.format("Unable to dispatch response (%d %s, Content-Type: %s)",
+                response.getRawStatusCode(), response.getStatusText(), response.getHeaders().getContentType());
     }
 
     public ClientHttpResponse getResponse() {

--- a/src/main/java/org/zalando/riptide/NoRouteException.java
+++ b/src/main/java/org/zalando/riptide/NoRouteException.java
@@ -20,6 +20,7 @@ package org.zalando.riptide;
  * ​⁣
  */
 
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestClientException;
 
 /**
@@ -27,9 +28,15 @@ import org.springframework.web.client.RestClientException;
  */
 public final class NoRouteException extends RestClientException {
 
-    public NoRouteException(final String message) {
+    private final ClientHttpResponse response;
+
+    NoRouteException(final String message, final ClientHttpResponse response) {
         super(message);
+        this.response = response;
     }
 
+    public ClientHttpResponse getResponse() {
+        return response;
+    }
 
 }

--- a/src/main/java/org/zalando/riptide/Router.java
+++ b/src/main/java/org/zalando/riptide/Router.java
@@ -99,7 +99,7 @@ final class Router {
             final Binding<A> binding = getWildcard(bindings);
             return binding.execute(response, converters);
         } else {
-            throw new NoRouteException(formatMessage(attribute, bindings));
+            throw new NoRouteException(formatMessage(attribute, bindings), response);
         }
     }
 

--- a/src/test/java/org/zalando/riptide/FailedDispatchTest.java
+++ b/src/test/java/org/zalando/riptide/FailedDispatchTest.java
@@ -103,10 +103,8 @@ public final class FailedDispatchTest {
                         .contentType(APPLICATION_JSON));
 
         exception.expect(NoRouteException.class);
-        exception.expectMessage("Unable to dispatch application/json");
-        exception.expectMessage("application/success+json");
-        exception.expectMessage("application/problem+json");
-        exception.expectMessage("application/vnd.error+json");
+        exception.expectMessage("Unable to dispatch response (200 OK, Content-Type: application/json)");
+        exception.expect(hasFeature("response", NoRouteException::getResponse, notNullValue()));
 
         unit.execute(GET, url)
                 .dispatch(contentType(),
@@ -231,10 +229,8 @@ public final class FailedDispatchTest {
                         .contentType(APPLICATION_JSON));
 
         exception.expect(NoRouteException.class);
-        exception.expectMessage("Unable to dispatch 201");
-        exception.expectMessage("200");
-        exception.expectMessage("301");
-        exception.expectMessage("404");
+        exception.expectMessage("Unable to dispatch response (201 Created, Content-Type: application/json)");
+        exception.expect(hasFeature("response", NoRouteException::getResponse, notNullValue()));
 
         unit.execute(POST, url)
                 .dispatch(series(),


### PR DESCRIPTION
This should cover most logging needs for the normal use case, i.e. it now contains the response code, status message and content type. @lukasniemeier-zalando This should reduce the need to wrap the whole call in a `try-catch` block, right?