### PR TITLE
Added support for Future<Capture>

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,7 @@ response will be routed to an action. An action can be one of the following type
 Consumers can be used to trigger some dedicated function and they work well if no return value is required.
 
 Functions on the other hand are used to apply a transformation and their result must be captured. Captured values can 
-later be retrieved, e.g. to produce a return value. Please be aware that captures are not available when using
-`AsyncRest`.
+later be retrieved, e.g. to produce a return value.
 
 ```java
 final Optional<Success> success = rest.execute(..)
@@ -184,6 +183,16 @@ dealing with an `Optional`:
 ```java
 return rest.execute(..)
         .dispatch(..)
+        .to(Success.class);
+```
+
+Please be aware that when using `AsyncRest` captures are returned as `Future<Capture>`, since the result may
+not be available immediately:
+
+```java
+return rest.execute(..)
+        .dispatch(..)
+        .get(10, SECONDS)
         .to(Success.class);
 ```
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ exception will be thrown in another thread. You can either retrieve the exceptio
 try {
     rest.execute(GET, url).dispatch(..).get(10, SECONDS);
 } catch (final ExecutionException e) {
-    // TODO handle e.getCause()
+    // TODO implement
 }
 ```
 
@@ -276,7 +276,9 @@ or alternatively register a callback for handling the exception asynchronously:
 
 ```java
 rest.execute(GET, url).dispatch(..)
-        .addCallback(success, exception -> {});
+        .addCallback(handle(e -> {
+            // TODO implement
+        }));
 ```
 
 The only special custom exception you may get is `NoRouteException`, if and only if there was no matching condition and 

--- a/src/main/java/org/zalando/riptide/AsyncDispatcher.java
+++ b/src/main/java/org/zalando/riptide/AsyncDispatcher.java
@@ -20,7 +20,6 @@ package org.zalando.riptide;
  * ​⁣
  */
 
-import com.google.common.util.concurrent.Futures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.client.ClientHttpResponse;
@@ -31,7 +30,6 @@ import org.springframework.util.concurrent.SettableListenableFuture;
 import org.springframework.util.concurrent.SuccessCallback;
 
 import java.util.List;
-import java.util.concurrent.Future;
 
 import static org.zalando.riptide.AsyncRest.handle;
 import static org.zalando.riptide.Binding.route;

--- a/src/main/java/org/zalando/riptide/AsyncRest.java
+++ b/src/main/java/org/zalando/riptide/AsyncRest.java
@@ -20,13 +20,11 @@ package org.zalando.riptide;
  * ​⁣
  */
 
-import com.google.gag.annotation.remark.OhNoYouDidnt;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.web.client.AsyncRestTemplate;
 
@@ -70,12 +68,6 @@ public final class AsyncRest {
 
     public static AsyncRest create(final AsyncRestTemplate template) {
         return new AsyncRest(template);
-    }
-
-    // syntactic sugar
-    @OhNoYouDidnt
-    public static FailureCallback handle(final FailureCallback callback) {
-        return callback;
     }
 
 }

--- a/src/main/java/org/zalando/riptide/AsyncRest.java
+++ b/src/main/java/org/zalando/riptide/AsyncRest.java
@@ -25,7 +25,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.web.client.AsyncRestTemplate;
 
 import java.net.URI;
@@ -68,6 +70,20 @@ public final class AsyncRest {
 
     public static AsyncRest create(final AsyncRestTemplate template) {
         return new AsyncRest(template);
+    }
+
+    public static <T> ListenableFutureCallback<T> handle(final FailureCallback callback) {
+        return new ListenableFutureCallback<T>() {
+            @Override
+            public void onSuccess(T result) {
+                // ignored
+            }
+
+            @Override
+            public void onFailure(Throwable ex) {
+                callback.onFailure(ex);
+            }
+        };
     }
 
 }

--- a/src/main/java/org/zalando/riptide/Binding.java
+++ b/src/main/java/org/zalando/riptide/Binding.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import static java.util.Arrays.asList;
-
 public final class Binding<A> implements Executor {
 
     private final Optional<A> attribute;
@@ -56,11 +54,6 @@ public final class Binding<A> implements Executor {
 
     static <A> Binding<A> create(final Optional<A> attribute, final Executor executor) {
         return new Binding<>(attribute, executor);
-    }
-
-    @SafeVarargs
-    public static <T> List<T> route(T... bindings) {
-        return asList(bindings);
     }
 
 }

--- a/src/test/java/org/zalando/riptide/AsyncTest.java
+++ b/src/test/java/org/zalando/riptide/AsyncTest.java
@@ -21,31 +21,41 @@ package org.zalando.riptide;
  */
 
 import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.web.client.AsyncRestTemplate;
 
+import java.io.IOException;
 import java.net.NoRouteToHostException;
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.Series.CLIENT_ERROR;
 import static org.springframework.http.HttpStatus.Series.SUCCESSFUL;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.zalando.riptide.Actions.pass;
 import static org.zalando.riptide.AsyncRest.handle;
 import static org.zalando.riptide.Binding.route;
+import static org.zalando.riptide.Conditions.anyStatus;
 import static org.zalando.riptide.Conditions.on;
 import static org.zalando.riptide.Selectors.series;
+import static org.zalando.riptide.Selectors.status;
 
 public final class AsyncTest {
 
@@ -125,6 +135,23 @@ public final class AsyncTest {
                 on(SUCCESSFUL).call(verifier));
 
         verify(verifier).accept(any());
+    }
+
+    @Test
+    public void shouldCapture() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        server.expect(requestTo(url)).andRespond(
+                withSuccess()
+                        .body(new ClassPathResource("account.json"))
+                        .contentType(APPLICATION_JSON));
+
+        final ClientHttpResponse response = unit.execute(GET, url)
+                .dispatch(status(),
+                        on(OK).capture())
+                .get(100, TimeUnit.MILLISECONDS)
+                .to(ClientHttpResponse.class);
+
+        assertThat(response.getStatusCode(), is(OK));
+        assertThat(response.getHeaders().getContentType(), is(APPLICATION_JSON));
     }
 
     @Test

--- a/src/test/java/org/zalando/riptide/AsyncTest.java
+++ b/src/test/java/org/zalando/riptide/AsyncTest.java
@@ -29,7 +29,6 @@ import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.web.client.AsyncRestTemplate;
 
 import java.io.IOException;
-import java.net.NoRouteToHostException;
 import java.net.URI;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -50,9 +49,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.zalando.riptide.Actions.pass;
-import static org.zalando.riptide.AsyncRest.handle;
 import static org.zalando.riptide.Binding.route;
-import static org.zalando.riptide.Conditions.anyStatus;
 import static org.zalando.riptide.Conditions.on;
 import static org.zalando.riptide.Selectors.series;
 import static org.zalando.riptide.Selectors.status;


### PR DESCRIPTION
Fixes #59 

The only downside to this is that changing a void method to a return type is breaking change (see http://stackoverflow.com/questions/3589946/retrofitting-void-methods-to-return-its-argument-to-facilitate-fluency-breaking/3589948#3589948). So this would require to go for Riptide 2.0.0