### PR TITLE
Feature/#56 allow call with parameterless function

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ response will be routed to an action. An action can be one of the following type
 | Action                                      | Syntax                         |
 |---------------------------------------------|--------------------------------|
 | `Consumer<ClientHttpResponse>`              | `on(..).call(..)`              |
+| `Runnable`                                  | `on(..).call(..)`              |
 | `Consumer<ResponseEntity<T>>`               | `on(.., ..).call(..)`          |
 | `Consumer<T>`                               | `on(.., ..).call(..)`          |
 | `Function<ClientHttpResponse, ?>` + capture | `on(..).map(..).capture()`     |
@@ -186,7 +187,7 @@ return rest.execute(..)
         .to(Success.class);
 ```
 
-Please note: All consumer/function based actions are **not** `java.util.function.Consumer` and 
+Please note: All consumer/function based actions are **not** `java.util.function.Consumer`, `java.lang.Runnable` and
 `java.util.function.Function` respectively, but custom version that support throwing checked exceptions. This should
 not have any negative impact since most of the time you won't pass in a custom implementation, but rather a lambda or
 a method reference.

--- a/src/main/java/org/zalando/riptide/ThrowingRunnable.java
+++ b/src/main/java/org/zalando/riptide/ThrowingRunnable.java
@@ -1,0 +1,28 @@
+package org.zalando.riptide;
+
+/*
+ * ⁣​
+ * Riptide
+ * ⁣⁣
+ * Copyright (C) 2016 Zalando SE
+ * ⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ​⁣
+ */
+
+@FunctionalInterface
+public interface ThrowingRunnable<X extends Exception> {
+
+    void run() throws X;
+
+}

--- a/src/main/java/org/zalando/riptide/UntypedCondition.java
+++ b/src/main/java/org/zalando/riptide/UntypedCondition.java
@@ -44,6 +44,13 @@ public final class UntypedCondition<A> {
         });
     }
 
+    public Binding<A> call(final ThrowingRunnable<?> consumer) {
+        return Binding.create(attribute, (response, converters) -> {
+            consumer.run();
+            return none();
+        });
+    }
+
     public Capturer<A> map(final ThrowingFunction<ClientHttpResponse, ?, ?> function) {
         return () -> Binding.create(attribute, (response, converters) ->
                 Capture.valueOf(function.apply(response)));

--- a/src/test/java/org/zalando/riptide/AsyncTest.java
+++ b/src/test/java/org/zalando/riptide/AsyncTest.java
@@ -75,6 +75,20 @@ public final class AsyncTest {
     }
 
     @Test
+    public void shouldCallWithoutParameters() {
+        server.expect(requestTo(url)).andRespond(withSuccess());
+
+        @SuppressWarnings("unchecked")
+        final ThrowingRunnable<RuntimeException> verifier = mock(ThrowingRunnable.class);
+
+        unit.execute(GET, url).dispatch(series(),
+                on(SUCCESSFUL).call(verifier));
+
+        verify(verifier).run();
+    }
+
+
+    @Test
     public void shouldCallWithHeaders() {
         server.expect(requestTo(url)).andRespond(withSuccess());
 
@@ -112,11 +126,11 @@ public final class AsyncTest {
 
         verify(verifier).accept(any());
     }
-    
+
     @Test
     public void shouldIgnoreException() {
         server.expect(requestTo(url)).andRespond(withSuccess());
-        
+
         unit.execute(GET, url).dispatch(series(),
                 on(CLIENT_ERROR).call(pass()));
     }

--- a/src/test/java/org/zalando/riptide/CallTest.java
+++ b/src/test/java/org/zalando/riptide/CallTest.java
@@ -107,6 +107,25 @@ public final class CallTest {
         verify(verifier).accept(any(AccountBody.class));
     }
 
+    @Test
+    public void shouldCallWithoutParameters() throws Exception {
+        server.expect(requestTo(url)).andRespond(
+                withSuccess()
+                        .body(new ClassPathResource("account.json"))
+                        .contentType(APPLICATION_JSON));
+
+        @SuppressWarnings("unchecked")
+        final ThrowingRunnable<Exception> verifier =
+                mock(ThrowingRunnable.class);
+
+        unit.execute(GET, url)
+                .dispatch(status(),
+                        on(OK).call(verifier),
+                        anyStatus().call(this::fail));
+
+        verify(verifier).run();
+    }
+
     @Test(expected = CheckedException.class)
     public void shouldThrowCheckedExceptionOnEntity() {
         server.expect(requestTo(url)).andRespond(


### PR DESCRIPTION
Attempt to implement #56.

This adds a `.call(...)` overload to both TypedCondition and UntypedCondition, accepting a ThrowingRunnable each.

I'm not sure the addition to TypedCondition is actually sensible (because why map to a type if you are then throwing it away?), please comment on this.