### PR TITLE
Made Rest.execute(HttpMethod, ..) public

### DIFF
--- a/riptide-core/src/main/java/org/zalando/riptide/Rest.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/Rest.java
@@ -90,17 +90,17 @@ public final class Rest {
         return execute(HttpMethod.TRACE, uri);
     }
 
-    private Requester execute(final HttpMethod method, final URI uri) {
-        return execute(arguments
-                .withMethod(method)
-                .withUri(uri));
-    }
-
-    private Requester execute(final HttpMethod method, final String uriTemplate, final Object... uriVariables) {
+    public Requester execute(final HttpMethod method, final String uriTemplate, final Object... uriVariables) {
         return execute(arguments
                 .withMethod(method)
                 .withUriTemplate(uriTemplate)
                 .withUriVariables(ImmutableList.copyOf(uriVariables)));
+    }
+
+    public Requester execute(final HttpMethod method, final URI uri) {
+        return execute(arguments
+                .withMethod(method)
+                .withUri(uri));
     }
 
     private Requester execute(final RequestArguments arguments) {


### PR DESCRIPTION
This allows for use cases where the http method is dynamically determined at runtime. Right now that requires a lookup/mapping from http method to function, e.g.

```java
switch (method) {
    case HEAD:
        return rest.head(uri);
    ...
}
```