### PR TITLE
GH-193 Adds support for dynamic base url

### DIFF
--- a/riptide-core/src/main/java/org/zalando/riptide/DefaultRequestArguments.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/DefaultRequestArguments.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import java.net.URI;
 import java.util.Optional;
+import java.util.function.Supplier;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,7 +27,7 @@ public final class DefaultRequestArguments implements RequestArguments {
     HttpMethod method;
 
     @Wither
-    URI baseUrl;
+    Supplier<URI> baseUrlProvider;
 
     @Wither
     String uriTemplate;
@@ -80,6 +81,11 @@ public final class DefaultRequestArguments implements RequestArguments {
                 .build(true).normalize().toUri();
 
         return withRequestUri(requestUri);
+    }
+
+    @Override
+    public URI getBaseUrl() {
+        return baseUrlProvider == null ? null : baseUrlProvider.get();
     }
 
 }

--- a/riptide-core/src/main/java/org/zalando/riptide/DefaultRequestArguments.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/DefaultRequestArguments.java
@@ -2,6 +2,8 @@ package org.zalando.riptide;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
+import java.net.URI;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,8 +11,11 @@ import lombok.Singular;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.Wither;
 import org.springframework.http.HttpMethod;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URI;
+import static org.springframework.web.util.UriComponentsBuilder.fromUri;
+import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
 
 @Getter
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
@@ -44,5 +49,37 @@ public final class DefaultRequestArguments implements RequestArguments {
 
     @Wither
     Object body;
+
+    public DefaultRequestArguments() {
+        this(null, null, null, ImmutableList.of(), null, ImmutableMultimap.of(), null, ImmutableMultimap.of(), null);
+    }
+
+    public DefaultRequestArguments withRequestUri() {
+        // expand uri template
+        final URI uri = Optional.ofNullable(getUri())
+                .orElseGet(() -> fromUriString(getUriTemplate())
+                        .buildAndExpand(getUriVariables().toArray())
+                        .encode()
+                        .toUri());
+
+        // resolve uri against base url
+        final URI resolved = getBaseUrl() == null ? uri : getBaseUrl().resolve(uri);
+
+        // encode query params
+        final MultiValueMap<String, String> queryParams;
+        {
+            final UriComponentsBuilder components = UriComponentsBuilder.newInstance();
+            getQueryParams().entries().forEach(entry
+                    -> components.queryParam(entry.getKey(), entry.getValue()));
+            queryParams = components.build().encode().getQueryParams();
+        }
+
+        // build request uri
+        final URI requestUri = fromUri(resolved)
+                .queryParams(queryParams)
+                .build(true).normalize().toUri();
+
+        return withRequestUri(requestUri);
+    }
 
 }

--- a/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
@@ -3,18 +3,10 @@ package org.zalando.riptide;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import org.springframework.http.HttpMethod;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import javax.annotation.Nullable;
 import java.net.URI;
-import java.util.Optional;
-
-import static org.springframework.web.util.UriComponentsBuilder.fromUri;
-import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
 
 public interface RequestArguments {
-    
+
     URI getBaseUrl();
 
     HttpMethod getMethod();
@@ -32,56 +24,5 @@ public interface RequestArguments {
     ImmutableMultimap<String, String> getHeaders();
 
     Object getBody();
-
-    RequestArguments withBaseUrl(@Nullable URI baseUrl);
-
-    RequestArguments withMethod(@Nullable HttpMethod method);
-
-    RequestArguments withUriTemplate(@Nullable String uriTemplate);
-
-    RequestArguments withUriVariables(@Nullable ImmutableList<Object> uriVariables);
-
-    RequestArguments withUri(@Nullable URI uri);
-
-    RequestArguments withQueryParams(@Nullable ImmutableMultimap<String, String> queryParams);
-
-    RequestArguments withRequestUri(@Nullable URI requestUri);
-
-    RequestArguments withHeaders(@Nullable ImmutableMultimap<String, String> headers);
-
-    RequestArguments withBody(@Nullable Object body);
-
-    default RequestArguments withRequestUri() {
-        // expand uri template
-        final URI uri = Optional.ofNullable(getUri())
-                .orElseGet(() -> fromUriString(getUriTemplate())
-                        .buildAndExpand(getUriVariables().toArray())
-                        .encode()
-                        .toUri());
-
-        // resolve uri against base url
-        final URI resolved = getBaseUrl() == null ? uri : getBaseUrl().resolve(uri);
-
-        // encode query params
-        final MultiValueMap<String, String> queryParams;
-        {
-            final UriComponentsBuilder components = UriComponentsBuilder.newInstance();
-            getQueryParams().entries().forEach(entry ->
-                    components.queryParam(entry.getKey(), entry.getValue()));
-            queryParams = components.build().encode().getQueryParams();
-        }
-
-        // build request uri
-        final URI requestUri = fromUri(resolved)
-                .queryParams(queryParams)
-                .build(true).normalize().toUri();
-
-        return withRequestUri(requestUri);
-    }
-
-    static RequestArguments create() {
-        return new DefaultRequestArguments(null, null, null, ImmutableList.of(), null, ImmutableMultimap.of(), null,
-                ImmutableMultimap.of(), null);
-    }
 
 }

--- a/riptide-core/src/main/java/org/zalando/riptide/Requester.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/Requester.java
@@ -23,14 +23,14 @@ public final class Requester extends Dispatcher {
 
     private final AsyncClientHttpRequestFactory requestFactory;
     private final MessageWorker worker;
-    private final RequestArguments arguments;
+    private final DefaultRequestArguments arguments;
     private final Plugin plugin;
 
     private final Multimap<String, String> query = LinkedHashMultimap.create();
     private final HttpHeaders headers = new HttpHeaders();
 
     public Requester(final AsyncClientHttpRequestFactory requestFactory, final MessageWorker worker,
-            final RequestArguments arguments, final Plugin plugin) {
+            final DefaultRequestArguments arguments, final Plugin plugin) {
         this.requestFactory = requestFactory;
         this.worker = worker;
         this.arguments = arguments;

--- a/riptide-core/src/main/java/org/zalando/riptide/Rest.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/Rest.java
@@ -8,6 +8,7 @@ import org.springframework.http.converter.HttpMessageConverter;
 import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -19,10 +20,10 @@ public final class Rest {
     private final Plugin plugin;
 
     Rest(final AsyncClientHttpRequestFactory requestFactory, final List<HttpMessageConverter<?>> converters,
-            @Nullable final URI baseUrl, final Plugin plugin) {
+            @Nullable final Supplier<URI> baseUrlProvider, final Plugin plugin) {
         this.requestFactory = checkNotNull(requestFactory, "request factory");
         this.worker = new MessageWorker(converters);
-        this.arguments = new DefaultRequestArguments().withBaseUrl(baseUrl);
+        this.arguments = new DefaultRequestArguments().withBaseUrlProvider(baseUrlProvider);
         this.plugin = plugin;
     }
 

--- a/riptide-core/src/main/java/org/zalando/riptide/Rest.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/Rest.java
@@ -15,14 +15,14 @@ public final class Rest {
 
     private final AsyncClientHttpRequestFactory requestFactory;
     private final MessageWorker worker;
-    private final RequestArguments arguments;
+    private final DefaultRequestArguments arguments;
     private final Plugin plugin;
 
     Rest(final AsyncClientHttpRequestFactory requestFactory, final List<HttpMessageConverter<?>> converters,
             @Nullable final URI baseUrl, final Plugin plugin) {
         this.requestFactory = checkNotNull(requestFactory, "request factory");
         this.worker = new MessageWorker(converters);
-        this.arguments = RequestArguments.create().withBaseUrl(baseUrl);
+        this.arguments = new DefaultRequestArguments().withBaseUrl(baseUrl);
         this.plugin = plugin;
     }
 
@@ -103,7 +103,7 @@ public final class Rest {
                 .withUri(uri));
     }
 
-    private Requester execute(final RequestArguments arguments) {
+    private Requester execute(final DefaultRequestArguments arguments) {
         return new Requester(requestFactory, worker, arguments, plugin);
     }
 

--- a/riptide-core/src/main/java/org/zalando/riptide/RestBuilder.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/RestBuilder.java
@@ -12,6 +12,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 public final class RestBuilder {
 
@@ -28,7 +29,7 @@ public final class RestBuilder {
 
     private AsyncClientHttpRequestFactory requestFactory;
     private final List<HttpMessageConverter<?>> converters = new ArrayList<>();
-    private URI baseUrl;
+    private Supplier<URI> baseUrlProvider;
     private final List<Plugin> plugins = new ArrayList<>();
 
     RestBuilder() {
@@ -59,7 +60,11 @@ public final class RestBuilder {
     }
 
     public RestBuilder baseUrl(@Nullable final URI baseUrl) {
-        this.baseUrl = baseUrl;
+        return baseUrlProvider(() -> baseUrl);
+    }
+
+    public RestBuilder baseUrlProvider(@Nullable final Supplier<URI> baseUrlProvider) {
+        this.baseUrlProvider = baseUrlProvider;
         return this;
     }
 
@@ -91,7 +96,7 @@ public final class RestBuilder {
     }
 
     public Rest build() {
-        return new Rest(requestFactory, converters(), baseUrl, plugin());
+        return new Rest(requestFactory, converters(), baseUrlProvider, plugin());
     }
 
     private List<HttpMessageConverter<?>> converters() {

--- a/riptide-core/src/test/java/org/zalando/riptide/DefaultRequestArgumentsTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/DefaultRequestArgumentsTest.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
@@ -30,6 +31,7 @@ public final class DefaultRequestArgumentsTest<T> {
 
     @Value
     public static final class Assertion<T> {
+
         BiFunction<DefaultRequestArguments, T, DefaultRequestArguments> wither;
         T argument;
         Function<DefaultRequestArguments, T> getter;
@@ -38,7 +40,7 @@ public final class DefaultRequestArgumentsTest<T> {
     @Parameters
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                {new Assertion<>(DefaultRequestArguments::withBaseUrl, URI.create("https://api.example.com"), DefaultRequestArguments::getBaseUrl)},
+                {new Assertion<>(DefaultRequestArguments::withBaseUrlProvider, () -> URI.create("https://api.example.com"), DefaultRequestArguments::getBaseUrlProvider)},
                 {new Assertion<>(DefaultRequestArguments::withMethod, HttpMethod.GET, DefaultRequestArguments::getMethod)},
                 {new Assertion<>(DefaultRequestArguments::withUriTemplate, "/{id}", DefaultRequestArguments::getUriTemplate)},
                 {new Assertion<>(DefaultRequestArguments::withUriVariables, ImmutableList.of(123), DefaultRequestArguments::getUriVariables)},
@@ -64,6 +66,28 @@ public final class DefaultRequestArgumentsTest<T> {
 
         assertThat(applied, is(not(sameInstance(unit))));
         assertThat(assertion.getter.apply(applied), is(sameInstance(assertion.argument)));
+    }
+
+    @Test
+    public void shouldGetBaseUrl() {
+        final URI uri = URI.create("https://example.com");
+        final DefaultRequestArguments applied = unit.withBaseUrlProvider(() -> uri);
+
+        assertThat(applied.getBaseUrl(), is(sameInstance(uri)));
+    }
+
+    @Test
+    public void shouldSupportNullBaseUrlProvider() {
+        final DefaultRequestArguments applied = unit.withBaseUrlProvider(null);
+
+        assertThat(applied.getBaseUrl(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSupportBaseUrlProviderReturningNull() {
+        final DefaultRequestArguments applied = unit.withBaseUrlProvider(() -> null);
+
+        assertThat(applied.getBaseUrl(), is(nullValue()));
     }
 
 }

--- a/riptide-core/src/test/java/org/zalando/riptide/DefaultRequestArgumentsTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/DefaultRequestArgumentsTest.java
@@ -26,41 +26,41 @@ public final class DefaultRequestArgumentsTest<T> {
     @Parameter
     public Assertion<T> assertion;
 
-    private final RequestArguments unit = RequestArguments.create();
+    private final DefaultRequestArguments unit = new DefaultRequestArguments();
 
     @Value
     public static final class Assertion<T> {
-        BiFunction<RequestArguments, T, RequestArguments> wither;
+        BiFunction<DefaultRequestArguments, T, DefaultRequestArguments> wither;
         T argument;
-        Function<RequestArguments, T> getter;
+        Function<DefaultRequestArguments, T> getter;
     }
 
     @Parameters
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                {new Assertion<>(RequestArguments::withBaseUrl, URI.create("https://api.example.com"), RequestArguments::getBaseUrl)},
-                {new Assertion<>(RequestArguments::withMethod, HttpMethod.GET, RequestArguments::getMethod)},
-                {new Assertion<>(RequestArguments::withUriTemplate, "/{id}", RequestArguments::getUriTemplate)},
-                {new Assertion<>(RequestArguments::withUriVariables, ImmutableList.of(123), RequestArguments::getUriVariables)},
-                {new Assertion<>(RequestArguments::withUri, URI.create("/123"), RequestArguments::getUri)},
-                {new Assertion<>(RequestArguments::withQueryParams, ImmutableMultimap.of("k", "v"), RequestArguments::getQueryParams)},
-                {new Assertion<>(RequestArguments::withRequestUri, URI.create("https://api.example.com/123?k=v"), RequestArguments::getRequestUri)},
-                {new Assertion<>(RequestArguments::withHeaders, ImmutableMultimap.of("Secret", "true"), RequestArguments::getHeaders)},
-                {new Assertion<>(RequestArguments::withBody, new Object(), RequestArguments::getBody)},
+                {new Assertion<>(DefaultRequestArguments::withBaseUrl, URI.create("https://api.example.com"), DefaultRequestArguments::getBaseUrl)},
+                {new Assertion<>(DefaultRequestArguments::withMethod, HttpMethod.GET, DefaultRequestArguments::getMethod)},
+                {new Assertion<>(DefaultRequestArguments::withUriTemplate, "/{id}", DefaultRequestArguments::getUriTemplate)},
+                {new Assertion<>(DefaultRequestArguments::withUriVariables, ImmutableList.of(123), DefaultRequestArguments::getUriVariables)},
+                {new Assertion<>(DefaultRequestArguments::withUri, URI.create("/123"), DefaultRequestArguments::getUri)},
+                {new Assertion<>(DefaultRequestArguments::withQueryParams, ImmutableMultimap.of("k", "v"), DefaultRequestArguments::getQueryParams)},
+                {new Assertion<>(DefaultRequestArguments::withRequestUri, URI.create("https://api.example.com/123?k=v"), DefaultRequestArguments::getRequestUri)},
+                {new Assertion<>(DefaultRequestArguments::withHeaders, ImmutableMultimap.of("Secret", "true"), DefaultRequestArguments::getHeaders)},
+                {new Assertion<>(DefaultRequestArguments::withBody, new Object(), DefaultRequestArguments::getBody)},
         });
     }
 
     @Test
     public void shouldOptimizeForReapplyingSameValue() {
-        final RequestArguments applied = assertion.wither.apply(unit, assertion.argument);
-        final RequestArguments appliedAgain = assertion.wither.apply(applied, assertion.argument);
+        final DefaultRequestArguments applied = assertion.wither.apply(unit, assertion.argument);
+        final DefaultRequestArguments appliedAgain = assertion.wither.apply(applied, assertion.argument);
 
         assertThat(appliedAgain, is(sameInstance(applied)));
     }
 
     @Test
     public void shouldModifyValue() {
-        final RequestArguments applied = assertion.wither.apply(unit, assertion.argument);
+        final DefaultRequestArguments applied = assertion.wither.apply(unit, assertion.argument);
 
         assertThat(applied, is(not(sameInstance(unit))));
         assertThat(assertion.getter.apply(applied), is(sameInstance(assertion.argument)));

--- a/riptide-core/src/test/java/org/zalando/riptide/DynamicBaseUrlTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/DynamicBaseUrlTest.java
@@ -1,0 +1,58 @@
+package org.zalando.riptide;
+
+import java.net.URI;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import static org.springframework.http.HttpStatus.Series.SUCCESSFUL;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.zalando.riptide.Bindings.on;
+import static org.zalando.riptide.Navigators.series;
+import static org.zalando.riptide.Route.pass;
+
+public class DynamicBaseUrlTest {
+
+    private final Rest unit;
+    private final MockRestServiceServer server;
+    private URI baseUrl;
+
+    public DynamicBaseUrlTest() {
+        final MockSetup setup = new MockSetup();
+
+        this.unit = setup.getRestBuilder().baseUrlProvider(this::getBaseUrl).build();
+        this.server = setup.getServer();
+    }
+
+    private URI getBaseUrl() {
+        return baseUrl;
+    }
+
+    @After
+    public void after() {
+        server.verify();
+    }
+
+    @Test
+    public void shouldUseDynamicBaseUrl() {
+        expectRequestTo("https://host1.example.com/123");
+        expectRequestTo("https://host2.example.com/123");
+
+        baseUrl = URI.create("https://host1.example.com");
+        unit.get("/123")
+                .dispatch(series(),
+                        on(SUCCESSFUL).call(pass()));
+
+        baseUrl = URI.create("https://host2.example.com");
+        unit.get("/123")
+                .dispatch(series(),
+                        on(SUCCESSFUL).call(pass()));
+    }
+
+    private void expectRequestTo(final String url) {
+        server.expect(requestTo(url))
+                .andRespond(withSuccess());
+    }
+
+}

--- a/riptide-hystrix/src/test/java/org/zalando/riptide/hystrix/HystrixPluginTest.java
+++ b/riptide-hystrix/src/test/java/org/zalando/riptide/hystrix/HystrixPluginTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpResponse;
-import org.zalando.riptide.RequestArguments;
+import org.zalando.riptide.DefaultRequestArguments;
 import org.zalando.riptide.RequestExecution;
 
 import java.io.IOException;
@@ -28,7 +28,7 @@ public final class HystrixPluginTest {
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
-    private final RequestArguments arguments = RequestArguments.create()
+    private final DefaultRequestArguments arguments = new DefaultRequestArguments()
             .withMethod(HttpMethod.GET)
             .withRequestUri(URI.create("https://api.example.com/"));
 


### PR DESCRIPTION
Fixes GH-193

This PR adds support for dynamic base URL.

`RequestArguments` interface was cleaned from `withX` builder methods. The rationale is that single responsibility of this interface is to represent view over request arguments. Since interface is public it is a breaking change. The impact should be discussed and change reverted if **really** necessary.

Decision should be made about providing accompanying `RestBuilder::baseUrlProvider(Supplier<String> baseUrlProvider)` method since base url often comes in form of a string value as well.