### PR TITLE
Registered a custom task scheduler, if none was present

### DIFF
--- a/riptide-backup/src/test/java/org/zalando/riptide/backup/BackupRequestPluginTest.java
+++ b/riptide-backup/src/test/java/org/zalando/riptide/backup/BackupRequestPluginTest.java
@@ -73,7 +73,7 @@ public final class BackupRequestPluginTest {
 
         unit.get("/bar")
                 .call(pass())
-                .get(2500, TimeUnit.MILLISECONDS);
+                .get(3, SECONDS);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/DefaultRiptideRegistrar.java
@@ -218,15 +218,11 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
         }
 
         if (client.getRetry() != null || client.getCircuitBreaker() != null) {
-            plugins.add(ref(registry.registerIfAbsent(id, FailsafePlugin.class, () -> {
-                final BeanDefinitionBuilder plugin = genericBeanDefinition(FailsafePlugin.class);
-
-                plugin.addConstructorArgValue(registerScheduler(id));
-                plugin.addConstructorArgReference(registerRetryPolicy(id, client));
-                plugin.addConstructorArgReference(registerCircuitBreaker(id, client));
-
-                return plugin;
-            })));
+            plugins.add(ref(registry.registerIfAbsent(id, FailsafePlugin.class, () ->
+                    genericBeanDefinition(FailsafePlugin.class)
+                            .addConstructorArgValue(registerScheduler(id))
+                            .addConstructorArgReference(registerRetryPolicy(id, client))
+                            .addConstructorArgReference(registerCircuitBreaker(id, client)))));
         }
 
         if (client.getBackupRequest() != null) {

--- a/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/RiptideAutoConfiguration.java
+++ b/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/RiptideAutoConfiguration.java
@@ -62,7 +62,10 @@ public class RiptideAutoConfiguration {
 
     @Configuration
     @ConditionalOnClass(Scheduled.class)
-    @AutoConfigureAfter(name = "org.zalando.tracer.spring.TracerAutoConfiguration")
+    @AutoConfigureAfter(name = {
+            "org.zalando.tracer.spring.TracerAutoConfiguration",
+            "org.zalando.tracer.spring.TracerSchedulingAutoConfiguration"
+    })
     @AutoConfigureBefore(name = "org.springframework.scheduling.annotation.SchedulingConfiguration")
     static class SchedulingAutoConfiguration {
 

--- a/riptide-spring-boot-starter/src/test/java/org/zalando/riptide/spring/AccessTokensImplicitDisableTest.java
+++ b/riptide-spring-boot-starter/src/test/java/org/zalando/riptide/spring/AccessTokensImplicitDisableTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -29,6 +30,7 @@ public final class AccessTokensImplicitDisableTest {
             RiptideAutoConfiguration.class,
             JacksonAutoConfiguration.class,
     })
+    @EnableScheduling
     public static class TestConfiguration {
 
     }

--- a/riptide-spring-boot-starter/src/test/resources/application-no-oauth.yml
+++ b/riptide-spring-boot-starter/src/test/resources/application-no-oauth.yml
@@ -24,12 +24,3 @@ riptide:
         success-threshold: 2 out of 5
       backup-request:
         delay: 250 milliseconds
-    ecb:
-      base-url: http://www.ecb.europa.eu
-      retry:
-        backoff:
-          delay: 500 milliseconds
-          max-delay: 3 seconds
-        max-retries: 4
-        max-duration: 10 seconds
-        jitter: 200 milliseconds

--- a/riptide-spring-boot-starter/src/test/resources/application-testing.yml
+++ b/riptide-spring-boot-starter/src/test/resources/application-testing.yml
@@ -11,4 +11,10 @@ riptide:
         keep-alive: 5 minutes
         queue-size: 10
     other:
-      base-url: http://example.com
+      retry:
+        backoff:
+          delay: 500 milliseconds
+          max-delay: 3 seconds
+        max-retries: 4
+        max-duration: 10 seconds
+        jitter: 200 milliseconds


### PR DESCRIPTION
Fixes #319 

Based on the idea from @lukasniemeier-zalando. We register a task scheduler (size = # of CPUs), if and only if no scheduler was registered before. We let `TracerAutoConfiguration` take precedence.