### PR TITLE
Updated README code sample

### DIFF
--- a/riptide-spring-boot-starter/README.md
+++ b/riptide-spring-boot-starter/README.md
@@ -374,7 +374,7 @@ overridden by name, **not** by type. As an example, the following code would add
 @Bean
 @Qualifier("example")
 public ClientHttpMessageConverters exampleHttpMessageConverters() {
-    return new ClientHttpMessageConverters(new Jaxb2RootElementHttpMessageConverter());
+    return new ClientHttpMessageConverters(singletonList(new Jaxb2RootElementHttpMessageConverter()));
 }
 ```
 


### PR DESCRIPTION
Aligned example of ClientHttpMessageConverters usage with its actual implementation. 
This method expects list of Converters, and not the single one. 