### PR TITLE
Added bill of materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,41 @@ Add the following dependency to your project:
 
 Additional modules/artifacts of Riptide always share the same version number.
 
+Alternatively, you can import our *bill of materials*...
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.zalando</groupId>
+      <artifactId>riptide-bom</artifactId>
+      <version>${riptide.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
+
+... which allows you to omit versions:
+
+```xml
+<dependencies>
+  <dependency>
+      <groupId>org.zalando</groupId>
+      <artifactId>riptide-core</artifactId>
+  </dependency>
+  <dependency>
+      <groupId>org.zalando</groupId>
+      <artifactId>riptide-failsafe</artifactId>
+  </dependency>
+  <dependency>
+      <groupId>org.zalando</groupId>
+      <artifactId>riptide-faults</artifactId>
+  </dependency>
+</dependencies>
+```
+
 ## Configuration
 
 Integration of your typical Spring Boot Application with Riptide, [Logbook](https://github.com/zalando/logbook) and

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 
     <modules>
         <module>riptide-backup</module>
+        <module>riptide-bom</module>
         <module>riptide-capture</module>
         <module>riptide-core</module>
         <module>riptide-failsafe</module>

--- a/riptide-bom/pom.xml
+++ b/riptide-bom/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.zalando</groupId>
+        <artifactId>riptide-parent</artifactId>
+        <version>2.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>riptide-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Riptide: Bill of Materials</name>
+    <description>Client side response routing</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- riptide -->
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-backup</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-capture</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-core</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-failsafe</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-faults</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-httpclient</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-metrics</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-problem</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-spring-boot-1.x-support</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-spring-boot-2.x-support</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-spring-boot-api</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-spring-boot-starter</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-stream</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
+                <artifactId>riptide-timeout</artifactId>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Riptide has already 10+ modules that produce individual artifacts. Users that depend on them will usually list them all as dependencies in their POMs. Right now we guarantee that version numbers across modules are always the same, i.e. a new release will release each module, even if it wasn't change.
That allows users right now already to use a single maven property `riptide.version` that is used for each dependency. 

This pull requests introduces a BOM (bill of material) as an alternative. The BOM can be imported in the `dependencyManagement` section of a POM. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The BOM removes the need to specify any version on individual riptide artifacts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
