### PR TITLE
Fixed single-digit issue

### DIFF
--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/CompoundDelayParser.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/CompoundDelayParser.java
@@ -1,0 +1,33 @@
+package org.zalando.riptide.failsafe;
+
+import lombok.extern.slf4j.Slf4j;
+import net.jodah.failsafe.util.Duration;
+
+import java.util.Collection;
+import java.util.Objects;
+
+@Slf4j
+final class CompoundDelayParser implements DelayParser {
+
+    private final Collection<DelayParser> parsers;
+
+    CompoundDelayParser(final Collection<DelayParser> parsers) {
+        this.parsers = parsers;
+    }
+
+    @Override
+    public Duration parse(final String value) {
+        final Duration delay = parsers.stream()
+                .map(parser -> parser.parse(value))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
+        if (delay == null) {
+            log.warn("Received unsupported 'Retry-After' header [{}]; will ignore it", value);
+        }
+
+        return delay;
+    }
+
+}

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/DelayParser.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/DelayParser.java
@@ -1,0 +1,12 @@
+package org.zalando.riptide.failsafe;
+
+import net.jodah.failsafe.util.Duration;
+
+import javax.annotation.Nullable;
+
+interface DelayParser {
+
+    @Nullable
+    Duration parse(String value);
+
+}

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/HttpDateDelayParser.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/HttpDateDelayParser.java
@@ -1,0 +1,42 @@
+package org.zalando.riptide.failsafe;
+
+import net.jodah.failsafe.util.Duration;
+
+import javax.annotation.Nullable;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+
+import static java.time.Duration.between;
+import static java.time.Instant.now;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+final class HttpDateDelayParser implements DelayParser {
+
+    private final Clock clock;
+
+    HttpDateDelayParser(final Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public Duration parse(final String value) {
+        return until(parseDate(value));
+    }
+
+    @Nullable
+    private Instant parseDate(final String value) {
+        try {
+            return Instant.from(RFC_1123_DATE_TIME.parse(value));
+        } catch (final DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private Duration until(@Nullable final Instant end) {
+        return end == null ? null : new Duration(between(now(clock), end).getSeconds(), SECONDS);
+    }
+
+}

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/RetryAfterDelayFunction.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/RetryAfterDelayFunction.java
@@ -7,17 +7,10 @@ import net.jodah.failsafe.util.Duration;
 import org.apiguardian.api.API;
 import org.zalando.riptide.HttpResponseException;
 
-import javax.annotation.Nullable;
 import java.time.Clock;
-import java.time.Instant;
-import java.time.format.DateTimeParseException;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
+import java.util.Arrays;
+import java.util.Optional;
 
-import static java.lang.Long.parseLong;
-import static java.time.Duration.between;
-import static java.time.Instant.now;
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 /**
@@ -27,67 +20,23 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 @Slf4j
 public final class RetryAfterDelayFunction implements DelayFunction<Object, Throwable> {
 
-    private final Pattern digit = Pattern.compile("\\d");
-
-    private final Clock clock;
+    private final DelayParser parser;
 
     public RetryAfterDelayFunction(final Clock clock) {
-        this.clock = clock;
+        this.parser = new CompoundDelayParser(Arrays.asList(
+                new SecondsDelayParser(),
+                new HttpDateDelayParser(clock)
+        ));
     }
 
     @Override
     public Duration computeDelay(final Object result, final Throwable failure, final ExecutionContext context) {
-        return failure instanceof HttpResponseException ? computeDelay((HttpResponseException) failure) : null;
-    }
-
-    @Nullable
-    private Duration computeDelay(final HttpResponseException failure) {
-        @Nullable final String retryAfter = failure.getResponseHeaders().getFirst("Retry-After");
-        return retryAfter == null ? null : toDuration(parseDelay(retryAfter));
-    }
-
-    /**
-     * The value of this field can be either an HTTP-date or a number of seconds to delay after the response
-     * is received.
-     *
-     * Retry-After = HTTP-date / delay-seconds
-     *
-     * @param retryAfter non-null header value
-     * @return the parsed delay in seconds
-     */
-    @Nullable
-    private Long parseDelay(final String retryAfter) {
-        return onlyDigits(retryAfter) ?
-                parseSeconds(retryAfter) :
-                secondsUntil(parseDate(retryAfter));
-    }
-
-    private boolean onlyDigits(final String s) {
-        return digit.matcher(s).matches();
-    }
-
-    private Long parseSeconds(final String retryAfter) {
-        return parseLong(retryAfter);
-    }
-
-    @Nullable
-    private Instant parseDate(final String retryAfter) {
-        try {
-            return Instant.from(RFC_1123_DATE_TIME.parse(retryAfter));
-        } catch (final DateTimeParseException e) {
-            log.warn("Received invalid 'Retry-After' header [{}]; will ignore it", retryAfter);
-            return null;
-        }
-    }
-
-    @Nullable
-    private Long secondsUntil(@Nullable final Instant end) {
-        return end == null ? null : between(now(clock), end).getSeconds();
-    }
-
-    @Nullable
-    private Duration toDuration(@Nullable final Long seconds) {
-        return seconds == null ? null : new Duration(seconds, TimeUnit.SECONDS);
+        return Optional.ofNullable(failure)
+                .filter(HttpResponseException.class::isInstance)
+                .map(HttpResponseException.class::cast)
+                .map(response -> response.getResponseHeaders().getFirst("Retry-After"))
+                .map(parser::parse)
+                .orElse(null);
     }
 
 }

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/SecondsDelayParser.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/SecondsDelayParser.java
@@ -1,0 +1,26 @@
+package org.zalando.riptide.failsafe;
+
+import com.google.common.base.CharMatcher;
+import net.jodah.failsafe.util.Duration;
+
+import static java.lang.Long.parseLong;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+final class SecondsDelayParser implements DelayParser {
+
+    private final CharMatcher digit = CharMatcher.inRange('0', '9').precomputed();
+
+    @Override
+    public Duration parse(final String value) {
+        if (isInteger(value)) {
+            return new Duration(parseLong(value), SECONDS);
+        }
+
+        return null;
+    }
+
+    private boolean isInteger(final String value) {
+        return digit.matchesAllOf(value) && !value.isEmpty();
+    }
+
+}

--- a/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/CompoundDelayParserTest.java
+++ b/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/CompoundDelayParserTest.java
@@ -1,0 +1,44 @@
+package org.zalando.riptide.failsafe;
+
+import net.jodah.failsafe.util.Duration;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class CompoundDelayParserTest {
+
+    private final DelayParser first = mock(DelayParser.class);
+    private final DelayParser second = mock(DelayParser.class);
+
+    private final DelayParser unit = new CompoundDelayParser(Arrays.asList(first, second));
+
+    @Test
+    public void shouldUseFirstNonNullDelay() {
+        when(first.parse("1")).thenReturn(new Duration(1, SECONDS));
+        when(second.parse("2")).thenReturn(new Duration(2, SECONDS));
+
+        assertEquals(new Duration(1, SECONDS), unit.parse("1"));
+    }
+
+    @Test
+    public void shouldIgnoreNullDelay() {
+        when(second.parse("2")).thenReturn(new Duration(2, SECONDS));
+
+        assertEquals(new Duration(2, SECONDS), unit.parse("2"));
+    }
+
+    @Test
+    public void shouldFallbackToNullDelay() {
+        when(first.parse("1")).thenReturn(new Duration(1, SECONDS));
+        when(second.parse("2")).thenReturn(new Duration(2, SECONDS));
+
+        assertNull(unit.parse("3"));
+    }
+
+}

--- a/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/FailsafePluginTest.java
+++ b/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/FailsafePluginTest.java
@@ -103,7 +103,7 @@ public class FailsafePluginTest {
     }
 
     @Test
-    public void shouldRetryOnDemand() {
+    public void shouldRetryExplicitly() {
         driver.addExpectation(onRequestTo("/baz"), giveEmptyResponse().withStatus(503));
         driver.addExpectation(onRequestTo("/baz"), giveEmptyResponse());
 

--- a/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/HttpDateDelayParserTest.java
+++ b/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/HttpDateDelayParserTest.java
@@ -1,0 +1,33 @@
+package org.zalando.riptide.failsafe;
+
+import net.jodah.failsafe.util.Duration;
+import org.junit.Test;
+
+import java.time.Clock;
+
+import static java.time.Instant.parse;
+import static java.time.ZoneOffset.UTC;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public final class HttpDateDelayParserTest {
+
+    private final DelayParser unit = new HttpDateDelayParser(Clock.fixed(parse("2018-06-24T01:19:37Z"), UTC));
+
+    @Test
+    public void shouldParseHttpDate() {
+        assertEquals(new Duration(17, SECONDS), unit.parse("Sun, 24 Jun 2018 01:19:54 GMT"));
+    }
+
+    @Test
+    public void shouldIgnoreSeconds() {
+        assertNull(unit.parse("17"));
+    }
+
+    @Test
+    public void shouldIgnoreIso8601() {
+        assertNull(unit.parse("2018-04-11T22:34:28Z"));
+    }
+
+}

--- a/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/SecondsDelayParserTest.java
+++ b/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/SecondsDelayParserTest.java
@@ -1,0 +1,34 @@
+package org.zalando.riptide.failsafe;
+
+import net.jodah.failsafe.util.Duration;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public final class SecondsDelayParserTest {
+
+    private final DelayParser unit = new SecondsDelayParser();
+
+    @Test
+    public void shouldParseSingleDigit() {
+        assertEquals(new Duration(1, SECONDS), unit.parse("1"));
+    }
+
+    @Test
+    public void shouldParseDoubleDigitDelay() {
+        assertEquals(new Duration(17, SECONDS), unit.parse("17"));
+    }
+
+    @Test
+    public void shouldIgnoreHttpDateDelay() {
+        assertNull(unit.parse("Wed, 11 Apr 2018 22:34:28 GMT"));
+    }
+
+    @Test
+    public void shouldIgnoreEmptyString() {
+        assertNull(unit.parse(""));
+    }
+
+}

--- a/riptide-spring-boot-starter/src/test/java/org/zalando/riptide/spring/ManualConfiguration.java
+++ b/riptide-spring-boot-starter/src/test/java/org/zalando/riptide/spring/ManualConfiguration.java
@@ -33,6 +33,7 @@ import org.zalando.riptide.OriginalStackTracePlugin;
 import org.zalando.riptide.UrlResolution;
 import org.zalando.riptide.backup.BackupRequestPlugin;
 import org.zalando.riptide.failsafe.FailsafePlugin;
+import org.zalando.riptide.failsafe.RetryException;
 import org.zalando.riptide.faults.FaultClassifier;
 import org.zalando.riptide.faults.TransientFaultException;
 import org.zalando.riptide.faults.TransientFaultPlugin;
@@ -123,6 +124,7 @@ public class ManualConfiguration {
                     .plugin(new FailsafePlugin(scheduler)
                             .withRetryPolicy(new RetryPolicy()
                                     .retryOn(TransientFaultException.class)
+                                    .retryOn(RetryException.class)
                                     .withBackoff(50, 2000, MILLISECONDS)
                                     .withMaxRetries(10)
                                     .withMaxDuration(2, SECONDS)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue with the `RetryAfterDelayFunction`, which only understands delays of less than 10 seconds.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `RetryAfterDelayFunction` incorrectly checks the input to be a single digit, rather than an integer number. That leads to the effect that any value that is greater than or equal to 10 will be ignored and retries will fallback to the configured delay.

While fixing this I ended up with an integration tests actually had to run 10 seconds to prove that the bug exists. I considered this too long, since riptide already takes a while to build. I refactored the code within the `RetryAfterDelayFunction` and tried to split it up into individual units, each having exactly one task:

- `RetryAfterDelayFunction`: Extract `Retry-After` header values from `HttpResponseException` 
- `CompoundDelayParser`: Delegate parsing of delays to specific parsers
- `SecondsDelayParser`: Parse delays expressed in seconds
- `HttpDateDelayParser`: Parse delays expressed as date times

I was now able to write specific tests for those individual units, which are quite a bit faster than the network-based integration tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
