### PR TITLE
Added support for failsafe listeners

### DIFF
--- a/riptide-failsafe/README.md
+++ b/riptide-failsafe/README.md
@@ -59,7 +59,8 @@ Http.builder()
             .withCircuitBreaker(new CircuitBreaker()
                     .withFailureThreshold(3, 10)
                     .withSuccessThreshold(5)
-                    .withDelay(1, TimeUnit.MINUTES)))
+                    .withDelay(1, TimeUnit.MINUTES))
+            .withListeners(myListeners))
     .build();
 ```
 

--- a/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/DefaultRiptideRegistrar.java
@@ -228,7 +228,7 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
                             .addConstructorArgValue(registerScheduler(id))
                             .addConstructorArgReference(registerRetryPolicy(id, client))
                             .addConstructorArgReference(registerCircuitBreaker(id, client))
-                            .addConstructorArgValue(registry.registerIfAbsent(id, Listeners.class)))));
+                            .addConstructorArgReference(registry.registerIfAbsent(id, Listeners.class)))));
         }
 
         if (client.getBackupRequest() != null) {

--- a/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/DefaultRiptideRegistrar.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.jodah.failsafe.CircuitBreaker;
+import net.jodah.failsafe.Listeners;
 import net.jodah.failsafe.RetryPolicy;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.NoHttpResponseException;
@@ -226,16 +227,17 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
                     genericBeanDefinition(FailsafePlugin.class)
                             .addConstructorArgValue(registerScheduler(id))
                             .addConstructorArgReference(registerRetryPolicy(id, client))
-                            .addConstructorArgReference(registerCircuitBreaker(id, client)))));
+                            .addConstructorArgReference(registerCircuitBreaker(id, client))
+                            .addConstructorArgValue(registry.registerIfAbsent(id, Listeners.class)))));
         }
 
         if (client.getBackupRequest() != null) {
             plugins.add(genericBeanDefinition(BackupRequestPlugin.class)
-                .addConstructorArgValue(registerScheduler(id))
-                .addConstructorArgValue(client.getBackupRequest().getDelay().getAmount())
-                .addConstructorArgValue(client.getBackupRequest().getDelay().getUnit())
-                .addConstructorArgValue(registerExecutor(id, client))
-                .getBeanDefinition());
+                    .addConstructorArgValue(registerScheduler(id))
+                    .addConstructorArgValue(client.getBackupRequest().getDelay().getAmount())
+                    .addConstructorArgValue(client.getBackupRequest().getDelay().getUnit())
+                    .addConstructorArgValue(registerExecutor(id, client))
+                    .getBeanDefinition());
         }
 
         if (client.getTimeout() != null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The failsafe plugin now has support to specify a listener that is registered when we configure failsafe. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm planning on adding support to record metrics for retries. This change is a prerequisite.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
