### PR TITLE
Added support for X-HTTP-Method-Override

### DIFF
--- a/riptide-backup/src/main/java/org/zalando/riptide/backup/BackupRequestPlugin.java
+++ b/riptide-backup/src/main/java/org/zalando/riptide/backup/BackupRequestPlugin.java
@@ -40,9 +40,20 @@ public final class BackupRequestPlugin implements Plugin {
             case GET:
             case HEAD:
                 return withBackup(execution);
+            case POST:
+                if (isGetWithBody(arguments)) {
+                    return withBackup(execution);
+                }
+
+                return execution;
             default:
                 return execution;
         }
+    }
+
+    private boolean isGetWithBody(final RequestArguments arguments) {
+        // TODO should use case-insensitive comparison
+        return arguments.getHeaders().containsEntry("X-HTTP-Method-Override", "GET");
     }
 
     private RequestExecution withBackup(final RequestExecution execution) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The backup plugin now considers requests with a `X-HTTP-Method-Override: GET` header as *GET with body* and therefore safe.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #410

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
