### PR TITLE
Fix placeholder resolving in binding

### DIFF
--- a/riptide-spring-boot-1.x-support/src/test/java/org/zalando/riptide/spring/SpringBoot1xSettingsParserTest.java
+++ b/riptide-spring-boot-1.x-support/src/test/java/org/zalando/riptide/spring/SpringBoot1xSettingsParserTest.java
@@ -5,6 +5,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.validation.BindException;
 
+import java.net.URI;
+
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -19,13 +21,15 @@ public final class SpringBoot1xSettingsParserTest {
     @Test
     public void shouldParse() {
         final ConfigurableEnvironment environment = new MockEnvironment()
-                .withProperty("riptide.clients.example.base-url", "https://example.com");
+                .withProperty("riptide.clients.example.base-url", "https://example.com")
+                .withProperty("riptide.oauth.access-token-url", "${RIPTIDE_TEST_ENV_VAR:https://example.com/oauth}");
         final SettingsParser unit = new SpringBoot1xSettingsParser();
 
         final RiptideProperties settings = unit.parse(environment);
 
         assertThat(settings.getClients().values(), hasSize(1));
         assertThat(settings.getClients().get("example").getBaseUrl(), is("https://example.com"));
+        assertThat(settings.getOauth().getAccessTokenUrl(), is(URI.create("https://example.com/oauth")));
     }
 
     @Test(expected = BindException.class)

--- a/riptide-spring-boot-2.x-support/src/main/java/org/zalando/riptide/spring/SpringBoot2xSettingsParser.java
+++ b/riptide-spring-boot-2.x-support/src/main/java/org/zalando/riptide/spring/SpringBoot2xSettingsParser.java
@@ -2,12 +2,10 @@ package org.zalando.riptide.spring;
 
 import org.apiguardian.api.API;
 import org.springframework.boot.context.properties.bind.Binder;
-import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.util.ClassUtils;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
-import static org.springframework.boot.context.properties.source.ConfigurationPropertySources.from;
 
 @API(status = INTERNAL)
 public final class SpringBoot2xSettingsParser implements SettingsParser {
@@ -20,8 +18,7 @@ public final class SpringBoot2xSettingsParser implements SettingsParser {
 
     @Override
     public RiptideProperties parse(final ConfigurableEnvironment environment) {
-        final Iterable<ConfigurationPropertySource> sources = from(environment.getPropertySources());
-        final Binder binder = new Binder(sources);
+        final Binder binder = Binder.get(environment);
 
         return binder.bind("riptide", RiptideProperties.class).orElseCreate(RiptideProperties.class);
     }

--- a/riptide-spring-boot-2.x-support/src/test/java/org/zalando/riptide/spring/SpringBoot2xSettingsParserTest.java
+++ b/riptide-spring-boot-2.x-support/src/test/java/org/zalando/riptide/spring/SpringBoot2xSettingsParserTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.net.URI;
+
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -18,13 +20,15 @@ public final class SpringBoot2xSettingsParserTest {
     @Test
     public void shouldParse() {
         final ConfigurableEnvironment environment = new MockEnvironment()
-                .withProperty("riptide.clients.example.base-url", "https://example.com");
+                .withProperty("riptide.clients.example.base-url", "https://example.com")
+                .withProperty("riptide.oauth.access-token-url", "${RIPTIDE_TEST_ENV_VAR:https://example.com/oauth}");
         final SettingsParser unit = new SpringBoot2xSettingsParser();
 
         final RiptideProperties settings = unit.parse(environment);
 
         assertThat(settings.getClients().values(), hasSize(1));
         assertThat(settings.getClients().get("example").getBaseUrl(), is("https://example.com"));
+        assertThat(settings.getOauth().getAccessTokenUrl(), is(URI.create("https://example.com/oauth")));
     }
 
 }


### PR DESCRIPTION
Fix placeholder resolving in binding

## Description
Allows for "placeholders" in properties of the `riptide` namespace.

## Motivation and Context
Currently it may be surprising that placeholders are not being handled/resolved in properties of the `riptide` namespace.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have added tests to cover my changes.
