### PR TITLE
test encoding

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @whiskeysierra @lukasniemeier-zalando @AlexanderYastrebov
+* @whiskeysierra @lukasniemeier-zalando @AlexanderYastrebov @patandrick

--- a/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
@@ -6,10 +6,12 @@ import org.apiguardian.api.API;
 import org.springframework.http.HttpMethod;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.nio.charset.Charset;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apiguardian.api.API.Status.STABLE;
@@ -95,8 +97,8 @@ public interface RequestArguments {
         {
             final UriComponentsBuilder components = UriComponentsBuilder.newInstance();
             getQueryParams().entries().forEach(entry ->
-                    components.queryParam(entry.getKey(), entry.getValue()));
-            queryParams = components.build().encode().getQueryParams();
+                    components.queryParam(entry.getKey(), UriUtils.encode(entry.getValue(), Charset.defaultCharset())));
+            queryParams = components.build().getQueryParams();
         }
 
         // build request uri

--- a/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
@@ -97,8 +97,8 @@ public interface RequestArguments {
         {
             final UriComponentsBuilder components = UriComponentsBuilder.newInstance();
             getQueryParams().entries().forEach(entry ->
-                    components.queryParam(entry.getKey(), UriUtils.encode(entry.getValue(), Charset.defaultCharset())));
-            queryParams = components.build().getQueryParams();
+                    components.queryParam(entry.getKey(), UriUtils.encode(entry.getValue(), "UTF-8")));
+            queryParams = components.build(true).getQueryParams();
         }
 
         // build request uri

--- a/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
@@ -4,19 +4,17 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import org.apiguardian.api.API;
 import org.springframework.http.HttpMethod;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.springframework.web.util.UriUtils;
+import org.zalando.fauxpas.FauxPas;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
-import java.nio.charset.Charset;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apiguardian.api.API.Status.STABLE;
-import static org.springframework.web.util.UriComponentsBuilder.fromUri;
 import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
+import static org.springframework.web.util.UriUtils.encode;
 
 @API(status = STABLE)
 public interface RequestArguments {
@@ -92,18 +90,13 @@ public interface RequestArguments {
             resolvedUri = getUrlResolution().resolve(baseUrl, unresolvedUri);
         }
 
+        final UriComponentsBuilder components = UriComponentsBuilder.newInstance();
         // encode query params
-        final MultiValueMap<String, String> queryParams;
-        {
-            final UriComponentsBuilder components = UriComponentsBuilder.newInstance();
-            getQueryParams().entries().forEach(entry ->
-                    components.queryParam(entry.getKey(), UriUtils.encode(entry.getValue(), "UTF-8")));
-            queryParams = components.build(true).getQueryParams();
-        }
+        getQueryParams().entries().forEach(FauxPas.throwingConsumer(entry ->
+                components.queryParam(entry.getKey(), encode(entry.getValue(), "UTF-8"))));
 
         // build request uri
-        final URI requestUri = fromUri(resolvedUri)
-                .queryParams(queryParams)
+        final URI requestUri = components.uri(resolvedUri)
                 .build(true).normalize().toUri();
 
         checkArgument(requestUri.isAbsolute(), "Request URI is not absolute");

--- a/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
@@ -116,7 +116,7 @@ public class RequesterTest {
 
     @Test
     public void shouldAppendedDateTimeQueryParams() {
-        expectRequestTo("https://test.datetimes.org/index.php?to=2018-05-21T10%3A24%3A47.788%2B00%3A00&from=2017-04-20T09%3A23%3A46.787Z");
+        expectRequestTo("https://test.datetimes.org/index.php?to=2018-05-21T10%3A24%3A47.788%2B00%3A00&from=2016-04-20T09%3A23%3A46.787Z");
 
         unit.head("https://test.datetimes.org/index.php")
                 .queryParam("to", "2018-05-21T10:24:47.788+00:00")

--- a/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
@@ -115,13 +115,21 @@ public class RequesterTest {
     }
 
     @Test
-    public void shouldEncodeAppendedDateTimeQueryParams() {
-        expectRequestTo("https://test.datetimes.org/index.php?to=2018-05-21T10%3A24%3A47.788&from=2017-04-20T09%3A23%3A46.787&team_id=1&team_id=2");
+    public void shouldAppendedDateTimeQueryParams() {
+        expectRequestTo("https://test.datetimes.org/index.php?to=2018-05-21T10%3A24%3A47.788&from=2017-04-20T09%3A23%3A46.787");
 
         unit.head("https://test.datetimes.org/index.php")
                 .queryParam("to", "2018-05-21T10:24:47.788")
                 .queryParam("from", "2017-04-20T09:23:46.787")
-                //one key, two values testing
+                .dispatch(series(),
+                        on(SUCCESSFUL).call(pass()));
+    }
+
+    @Test
+    public void shouldEncodeAppendedMultiValueQueryParams() {
+        expectRequestTo("https://test.datetimes.org/index.php?team_id=1&team_id=2");
+
+        unit.head("https://test.datetimes.org/index.php")
                 .queryParam("team_id", "1")
                 .queryParam("team_id", "2")
                 .dispatch(series(),

--- a/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
@@ -120,7 +120,7 @@ public class RequesterTest {
 
         unit.head("https://test.datetimes.org/index.php")
                 .queryParam("to", "2018-05-21T10:24:47.788+00:00")
-                .queryParam("from", "2017-04-20T09:23:46.787Z")
+                .queryParam("from", "2016-04-20T09:23:46.787Z")
                 .dispatch(series(),
                         on(SUCCESSFUL).call(pass()));
     }

--- a/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
@@ -104,7 +104,7 @@ public class RequesterTest {
 
     @Test
     public void shouldEncodeAppendedQueryParams() {
-        expectRequestTo("https://ru.wiktionary.org/w/index.php?title=%D0%A1%D0%BB%D1%83%D0%B6%D0%B5%D0%B1%D0%BD%D0%B0%D1%8F:%D0%9A%D0%BE%D0%BB%D0%BB%D0%B5%D0%BA%D1%86%D0%B8%D1%8F_%D0%BA%D0%BD%D0%B8%D0%B3&bookcmd=book_creator&referer=%D0%97%D0%B0%D0%B3%D0%BB%D0%B0%D0%B2%D0%BD%D0%B0%D1%8F%20%D1%81%D1%82%D1%80%D0%B0%D0%BD%D0%B8%D1%86%D0%B0");
+        expectRequestTo("https://ru.wiktionary.org/w/index.php?title=%D0%A1%D0%BB%D1%83%D0%B6%D0%B5%D0%B1%D0%BD%D0%B0%D1%8F%3A%D0%9A%D0%BE%D0%BB%D0%BB%D0%B5%D0%BA%D1%86%D0%B8%D1%8F_%D0%BA%D0%BD%D0%B8%D0%B3&bookcmd=book_creator&referer=%D0%97%D0%B0%D0%B3%D0%BB%D0%B0%D0%B2%D0%BD%D0%B0%D1%8F%20%D1%81%D1%82%D1%80%D0%B0%D0%BD%D0%B8%D1%86%D0%B0");
 
         unit.head("https://ru.wiktionary.org/w/index.php")
                 .queryParam("title", "Служебная:Коллекция_книг")
@@ -116,10 +116,14 @@ public class RequesterTest {
 
     @Test
     public void shouldEncodeAppendedDateTimeQueryParams() {
-        expectRequestTo("https://test.datetimes.org/index.php?from=2018-05-21T10%3A24%3A47.788%2B02%3A00");
+        expectRequestTo("https://test.datetimes.org/index.php?to=2018-05-21T10%3A24%3A47.788&from=2017-04-20T09%3A23%3A46.787&team_id=1&team_id=2");
 
         unit.head("https://test.datetimes.org/index.php")
-                .queryParam("from", "2018-05-21T10:24:47.788+02:00")
+                .queryParam("to", "2018-05-21T10:24:47.788")
+                .queryParam("from", "2017-04-20T09:23:46.787")
+                //one key, two values testing
+                .queryParam("team_id", "1")
+                .queryParam("team_id", "2")
                 .dispatch(series(),
                         on(SUCCESSFUL).call(pass()));
     }

--- a/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
@@ -126,7 +126,7 @@ public class RequesterTest {
     }
 
     @Test
-    public void shouldEncodeAppendedMultiValueQueryParams() {
+    public void shouldAppendMultiValueQueryParams() {
         expectRequestTo("https://test.datetimes.org/index.php?team_id=1&team_id=2");
 
         unit.head("https://test.datetimes.org/index.php")

--- a/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
@@ -116,11 +116,11 @@ public class RequesterTest {
 
     @Test
     public void shouldAppendedDateTimeQueryParams() {
-        expectRequestTo("https://test.datetimes.org/index.php?to=2018-05-21T10%3A24%3A47.788&from=2017-04-20T09%3A23%3A46.787");
+        expectRequestTo("https://test.datetimes.org/index.php?to=2018-05-21T10%3A24%3A47.788%2B00%3A00&from=2017-04-20T09%3A23%3A46.787Z");
 
         unit.head("https://test.datetimes.org/index.php")
-                .queryParam("to", "2018-05-21T10:24:47.788")
-                .queryParam("from", "2017-04-20T09:23:46.787")
+                .queryParam("to", "2018-05-21T10:24:47.788+00:00")
+                .queryParam("from", "2017-04-20T09:23:46.787Z")
                 .dispatch(series(),
                         on(SUCCESSFUL).call(pass()));
     }

--- a/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/RequesterTest.java
@@ -115,6 +115,16 @@ public class RequesterTest {
     }
 
     @Test
+    public void shouldEncodeAppendedDateTimeQueryParams() {
+        expectRequestTo("https://test.datetimes.org/index.php?from=2018-05-21T10%3A24%3A47.788%2B02%3A00");
+
+        unit.head("https://test.datetimes.org/index.php")
+                .queryParam("from", "2018-05-21T10:24:47.788+02:00")
+                .dispatch(series(),
+                        on(SUCCESSFUL).call(pass()));
+    }
+
+    @Test
     public void shouldExpandOnGetWithHeaders() {
         expectRequestTo("https://api.example.com/123");
 


### PR DESCRIPTION
test for expected encoding of datetime (will fail)

## Description
We had unexpected issues with datetimes like 
2018-05-21T10:24:47.788+02:00 which are not encoded for the url as a query parameter.
If you encode manually before the request (2018-05-21T10%3A24%3A47.788%2B02%3A00)
then this will be encoded again to "2018-05-21T10%253A24%253A47.788%252B02%253A00"

