### PR TITLE
Add token info uri to riptide properties

### DIFF
--- a/riptide-spring-boot-api/src/main/java/org/zalando/riptide/spring/RiptideProperties.java
+++ b/riptide-spring-boot-api/src/main/java/org/zalando/riptide/spring/RiptideProperties.java
@@ -3,12 +3,14 @@ package org.zalando.riptide.spring;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.apiguardian.api.API;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.zalando.riptide.UrlResolution;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -62,6 +64,7 @@ public final class RiptideProperties {
     @AllArgsConstructor
     public static final class GlobalOAuth {
         private URI accessTokenUrl;
+        private URI tokenInfoUrl;
         private Path credentialsDirectory;
         private TimeSpan schedulingPeriod = TimeSpan.of(5, SECONDS);
         private TimeSpan connectTimeout = TimeSpan.of(1, SECONDS);

--- a/riptide-spring-boot-starter/README.md
+++ b/riptide-spring-boot-starter/README.md
@@ -214,6 +214,7 @@ You can now define new clients and override default configuration in your `appli
 riptide:
   oauth:
     access-token-url: https://auth.example.com
+    token-info-url: https://info.example.com
     credentials-directory: /secrets
     scheduling-period: 10 seconds
     connect-timeout: 1 second
@@ -289,6 +290,7 @@ For a complete overview of available properties, they type and default value ple
 | `│   └── timeout`                       | `TimeSpan`     | none                                             |
 | `├── oauth`                             |                |                                                  |
 | `│   ├── access-token-url`              | `URI`          | env var `ACCESS_TOKEN_URL`                       |
+| `│   ├── token-info-url`                | `URI`          | none                                             |
 | `│   ├── credentials-directory`         | `Path`         | env var `CREDENTIALS_DIR`                        |
 | `│   ├── scheduling-period`             | `TimeSpan`     | `5 seconds`                                      |
 | `│   ├── connetion-timeout`             | `TimeSpan`     | `1 second`                                       |

--- a/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/AccessTokensFactory.java
+++ b/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/AccessTokensFactory.java
@@ -24,6 +24,7 @@ final class AccessTokensFactory {
         final RiptideProperties.GlobalOAuth oAuth = properties.getOauth();
 
         final URI accessTokenUrl = getAccessTokenUrl(oAuth);
+        @Nullable final URI tokenInfoUrl = getTokenInfoUrl(oAuth);
         @Nullable final Path directory = oAuth.getCredentialsDirectory();
         final TimeSpan connectTimeout = oAuth.getConnectTimeout();
         final TimeSpan socketTimeout = oAuth.getSocketTimeout();
@@ -48,7 +49,7 @@ final class AccessTokensFactory {
                     .done();
         });
 
-        return builder.start();
+        return tokenInfoUrl != null ? builder.tokenInfoUri(tokenInfoUrl).start() : builder.start();
     }
 
     private static JsonFileBackedClientCredentialsProvider getClientCredentialsProvider(@Nullable final Path directory) {
@@ -71,6 +72,12 @@ final class AccessTokensFactory {
                 "but at least one client requires OAuth");
 
         return accessTokenUrl;
+    }
+
+    private static URI getTokenInfoUrl(final RiptideProperties.GlobalOAuth oauth) {
+        @Nullable final URI tokenInfoUrl = oauth.getTokenInfoUrl();
+
+        return tokenInfoUrl;
     }
 
 }

--- a/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/Defaulting.java
+++ b/riptide-spring-boot-starter/src/main/java/org/zalando/riptide/spring/Defaulting.java
@@ -72,6 +72,7 @@ final class Defaulting {
         return new GlobalOAuth(
                 either(base.getAccessTokenUrl(),
                         Optional.ofNullable(getenv("ACCESS_TOKEN_URL")).map(URI::create).orElse(null)),
+                base.getTokenInfoUrl(),
                 base.getCredentialsDirectory(),
                 base.getSchedulingPeriod(),
                 either(base.getConnectTimeout(), defaults.getConnectTimeout()),

--- a/riptide-spring-boot-starter/src/test/java/org/zalando/riptide/spring/AccessTokensWithTokenInfoUriTest.java
+++ b/riptide-spring-boot-starter/src/test/java/org/zalando/riptide/spring/AccessTokensWithTokenInfoUriTest.java
@@ -1,0 +1,60 @@
+package org.zalando.riptide.spring;
+
+import com.google.gag.annotation.remark.Hack;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.zalando.stups.tokens.AccessTokens;
+import org.zalando.stups.tokens.ClientCredentials;
+import org.zalando.stups.tokens.ClientCredentialsProvider;
+import org.zalando.stups.tokens.TokenRefresherConfiguration;
+import org.zalando.stups.tokens.UserCredentials;
+import org.zalando.stups.tokens.UserCredentialsProvider;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@ActiveProfiles(profiles = "token-info-url", inheritProfiles = false)
+@Component
+public final class AccessTokensWithTokenInfoUriTest {
+
+    @Configuration
+    @ImportAutoConfiguration({
+            RiptideAutoConfiguration.class,
+            JacksonAutoConfiguration.class,
+    })
+    public static class TestConfiguration {
+
+    }
+
+    @Autowired
+    private AccessTokens accessTokens;
+
+    @Test
+    public void shouldSetTokenIfoUrl() throws NoSuchFieldException, IllegalAccessException {
+        final TokenRefresherConfiguration configuration = getConfiguration();
+
+        assertThat(configuration.getTokenInfoUri(), is(URI.create("http://another-example.com")));
+    }
+
+    @Hack
+    private TokenRefresherConfiguration getConfiguration() throws NoSuchFieldException, IllegalAccessException {
+        final Class<? extends AccessTokens> type = accessTokens.getClass();
+        final Field field = type.getSuperclass().getDeclaredField("configuration");
+        field.setAccessible(true);
+        return (TokenRefresherConfiguration) field.get(accessTokens);
+    }
+
+}

--- a/riptide-spring-boot-starter/src/test/java/org/zalando/riptide/spring/AccessTokensWithoutTokenInfoUriTest.java
+++ b/riptide-spring-boot-starter/src/test/java/org/zalando/riptide/spring/AccessTokensWithoutTokenInfoUriTest.java
@@ -1,0 +1,57 @@
+package org.zalando.riptide.spring;
+
+import com.google.gag.annotation.remark.Hack;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.zalando.stups.tokens.AccessTokens;
+import org.zalando.stups.tokens.TokenRefresherConfiguration;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@ActiveProfiles(profiles = "no-token-info-url", inheritProfiles = false)
+@Component
+public final class AccessTokensWithoutTokenInfoUriTest {
+
+    @Configuration
+    @ImportAutoConfiguration({
+            RiptideAutoConfiguration.class,
+            JacksonAutoConfiguration.class,
+    })
+    public static class TestConfiguration {
+
+    }
+
+    @Autowired
+    private AccessTokens accessTokens;
+
+    @Test
+    public void shouldSetTokenIfoUrl() throws NoSuchFieldException, IllegalAccessException {
+        final TokenRefresherConfiguration configuration = getConfiguration();
+
+        assertThat(configuration.getTokenInfoUri(), nullValue());
+    }
+
+    @Hack
+    private TokenRefresherConfiguration getConfiguration() throws NoSuchFieldException, IllegalAccessException {
+        final Class<? extends AccessTokens> type = accessTokens.getClass();
+        final Field field = type.getSuperclass().getDeclaredField("configuration");
+        field.setAccessible(true);
+        return (TokenRefresherConfiguration) field.get(accessTokens);
+    }
+
+}

--- a/riptide-spring-boot-starter/src/test/resources/application-no-token-info-url.yml
+++ b/riptide-spring-boot-starter/src/test/resources/application-no-token-info-url.yml
@@ -1,0 +1,19 @@
+riptide:
+  defaults:
+    retry:
+      backoff:
+        delay: 500 milliseconds
+        max-delay: 3 seconds
+        delay-factor: 3
+  oauth:
+    access-token-url: http://example.com
+    credentials-directory: src/test/resources
+  clients:
+    example:
+      oauth.scopes:
+        - example.read
+      retry:
+        backoff:
+          delay: 200 milliseconds
+          max-delay: 5 seconds
+          delay-factor: 2

--- a/riptide-spring-boot-starter/src/test/resources/application-token-info-url.yml
+++ b/riptide-spring-boot-starter/src/test/resources/application-token-info-url.yml
@@ -1,0 +1,20 @@
+riptide:
+  defaults:
+    retry:
+      backoff:
+        delay: 500 milliseconds
+        max-delay: 3 seconds
+        delay-factor: 3
+  oauth:
+    access-token-url: http://example.com
+    token-info-url: http://another-example.com
+    credentials-directory: src/test/resources
+  clients:
+    example:
+      oauth.scopes:
+        - example.read
+      retry:
+        backoff:
+          delay: 200 milliseconds
+          max-delay: 5 seconds
+          delay-factor: 2


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->
When using riptide, we get a logging warning from org.zalando.stups.tokens.TokenVerifyRunner with "No AccessToken-Verification enabled because no 'tokenInfoUri' was configured"

## Detailed Description
I propose that `tokenInfoUrl` is added to `RiptideProperties.GlobalOAuth` as an optional property.

## Context
<!--- Why is this change important to you? How would you use it? -->
<!--- How can it benefit other users? -->
We try to have only warnings and errors in our logs when it is something that we should act on it, so we would like to remove this warning.

## Possible Implementation
<!--- Not obligatory, but suggest an idea for implementing addition or change -->
