### PR TITLE
Added attribute support

### DIFF
--- a/riptide-core/src/main/java/org/zalando/riptide/Attribute.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/Attribute.java
@@ -1,0 +1,9 @@
+package org.zalando.riptide;
+
+public interface Attribute<T> {
+
+    static <T> Attribute<T> generate() {
+        return new DefaultAttribute<>();
+    }
+
+}

--- a/riptide-core/src/main/java/org/zalando/riptide/AttributeStage.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/AttributeStage.java
@@ -1,0 +1,10 @@
+package org.zalando.riptide;
+
+import org.apiguardian.api.API;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+@API(status = STABLE)
+public abstract class AttributeStage extends QueryStage {
+    public abstract <T> AttributeStage attribute(Attribute<T> attribute, T value);
+}

--- a/riptide-core/src/main/java/org/zalando/riptide/DefaultAttribute.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/DefaultAttribute.java
@@ -1,0 +1,5 @@
+package org.zalando.riptide;
+
+final class DefaultAttribute<T> implements Attribute<T> {
+
+}

--- a/riptide-core/src/main/java/org/zalando/riptide/DefaultHttp.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/DefaultHttp.java
@@ -1,8 +1,6 @@
 package org.zalando.riptide;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMultimap;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -13,11 +11,8 @@ import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
-import static org.springframework.http.HttpHeaders.readOnlyHttpHeaders;
 
 final class DefaultHttp implements Http {
-
-    private static final HttpHeaders EMPTY = readOnlyHttpHeaders(new HttpHeaders());
 
     private final Executor executor;
     private final ClientHttpRequestFactory requestFactory;
@@ -38,127 +33,127 @@ final class DefaultHttp implements Http {
     }
 
     @Override
-    public final QueryStage get(final String uriTemplate, final Object... urlVariables) {
+    public final AttributeStage get(final String uriTemplate, final Object... urlVariables) {
         return execute(HttpMethod.GET, uriTemplate, urlVariables);
     }
 
     @Override
-    public final QueryStage get(final URI uri) {
+    public final AttributeStage get(final URI uri) {
         return execute(HttpMethod.GET, uri);
     }
 
     @Override
-    public final QueryStage get() {
+    public final AttributeStage get() {
         return execute(HttpMethod.GET);
     }
 
     @Override
-    public final QueryStage head(final String uriTemplate, final Object... urlVariables) {
+    public final AttributeStage head(final String uriTemplate, final Object... urlVariables) {
         return execute(HttpMethod.HEAD, uriTemplate, urlVariables);
     }
 
     @Override
-    public final QueryStage head(final URI uri) {
+    public final AttributeStage head(final URI uri) {
         return execute(HttpMethod.HEAD, uri);
     }
 
     @Override
-    public final QueryStage head() {
+    public final AttributeStage head() {
         return execute(HttpMethod.HEAD);
     }
 
     @Override
-    public final QueryStage post(final String uriTemplate, final Object... urlVariables) {
+    public final AttributeStage post(final String uriTemplate, final Object... urlVariables) {
         return execute(HttpMethod.POST, uriTemplate, urlVariables);
     }
 
     @Override
-    public final QueryStage post(final URI uri) {
+    public final AttributeStage post(final URI uri) {
         return execute(HttpMethod.POST, uri);
     }
 
     @Override
-    public final QueryStage post() {
+    public final AttributeStage post() {
         return execute(HttpMethod.POST);
     }
 
     @Override
-    public final QueryStage put(final String uriTemplate, final Object... urlVariables) {
+    public final AttributeStage put(final String uriTemplate, final Object... urlVariables) {
         return execute(HttpMethod.PUT, uriTemplate, urlVariables);
     }
 
     @Override
-    public final QueryStage put(final URI uri) {
+    public final AttributeStage put(final URI uri) {
         return execute(HttpMethod.PUT, uri);
     }
 
     @Override
-    public final QueryStage put() {
+    public final AttributeStage put() {
         return execute(HttpMethod.PUT);
     }
 
     @Override
-    public final QueryStage patch(final String uriTemplate, final Object... urlVariables) {
+    public final AttributeStage patch(final String uriTemplate, final Object... urlVariables) {
         return execute(HttpMethod.PATCH, uriTemplate, urlVariables);
     }
 
     @Override
-    public final QueryStage patch(final URI uri) {
+    public final AttributeStage patch(final URI uri) {
         return execute(HttpMethod.PATCH, uri);
     }
 
     @Override
-    public final QueryStage patch() {
+    public final AttributeStage patch() {
         return execute(HttpMethod.PATCH);
     }
 
     @Override
-    public final QueryStage delete(final String uriTemplate, final Object... urlVariables) {
+    public final AttributeStage delete(final String uriTemplate, final Object... urlVariables) {
         return execute(HttpMethod.DELETE, uriTemplate, urlVariables);
     }
 
     @Override
-    public final QueryStage delete(final URI uri) {
+    public final AttributeStage delete(final URI uri) {
         return execute(HttpMethod.DELETE, uri);
     }
 
     @Override
-    public final QueryStage delete() {
+    public final AttributeStage delete() {
         return execute(HttpMethod.DELETE);
     }
 
     @Override
-    public final QueryStage options(final String uriTemplate, final Object... urlVariables) {
+    public final AttributeStage options(final String uriTemplate, final Object... urlVariables) {
         return execute(HttpMethod.OPTIONS, uriTemplate, urlVariables);
     }
 
     @Override
-    public final QueryStage options(final URI uri) {
+    public final AttributeStage options(final URI uri) {
         return execute(HttpMethod.OPTIONS, uri);
     }
 
     @Override
-    public final QueryStage options() {
+    public final AttributeStage options() {
         return execute(HttpMethod.OPTIONS);
     }
 
     @Override
-    public final QueryStage trace(final String uriTemplate, final Object... urlVariables) {
+    public final AttributeStage trace(final String uriTemplate, final Object... urlVariables) {
         return execute(HttpMethod.TRACE, uriTemplate, urlVariables);
     }
 
     @Override
-    public final QueryStage trace(final URI uri) {
+    public final AttributeStage trace(final URI uri) {
         return execute(HttpMethod.TRACE, uri);
     }
 
     @Override
-    public final QueryStage trace() {
+    public final AttributeStage trace() {
         return execute(HttpMethod.TRACE);
     }
 
     @Override
-    public QueryStage execute(final HttpMethod method, final String uriTemplate, final Object... uriVariables) {
+    public AttributeStage execute(final HttpMethod method, final String uriTemplate, final Object... uriVariables) {
         return execute(arguments
                 .withMethod(method)
                 .withBaseUrl(baseUrlProvider.get())
@@ -167,7 +162,7 @@ final class DefaultHttp implements Http {
     }
 
     @Override
-    public QueryStage execute(final HttpMethod method, final URI uri) {
+    public AttributeStage execute(final HttpMethod method, final URI uri) {
         return execute(arguments
                 .withMethod(method)
                 .withBaseUrl(baseUrlProvider.get())
@@ -175,15 +170,14 @@ final class DefaultHttp implements Http {
     }
 
     @Override
-    public QueryStage execute(final HttpMethod method) {
+    public AttributeStage execute(final HttpMethod method) {
         return execute(arguments
                 .withMethod(method)
                 .withBaseUrl(baseUrlProvider.get()));
     }
 
-    private QueryStage execute(final RequestArguments arguments) {
-        return new Requester(executor, requestFactory, worker, arguments, plugin,
-                ImmutableMultimap.of(), ImmutableMultimap.of());
+    private AttributeStage execute(final RequestArguments arguments) {
+        return new Requester(executor, requestFactory, worker, arguments, plugin);
     }
 
 }

--- a/riptide-core/src/main/java/org/zalando/riptide/DefaultRequestArguments.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/DefaultRequestArguments.java
@@ -1,6 +1,7 @@
 package org.zalando.riptide;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -11,16 +12,17 @@ import lombok.experimental.Wither;
 import org.apiguardian.api.API;
 import org.springframework.http.HttpMethod;
 
+import javax.annotation.Nullable;
 import java.net.URI;
+import java.util.Optional;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
-// TODO package private?
 @API(status = INTERNAL)
 @Getter
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public final class DefaultRequestArguments implements RequestArguments {
+final class DefaultRequestArguments implements RequestArguments {
 
     @Wither
     HttpMethod method;
@@ -42,6 +44,9 @@ public final class DefaultRequestArguments implements RequestArguments {
     URI uri;
 
     @Wither
+    ImmutableMap<Attribute<?>, Object> attributes;
+
+    @Wither
     ImmutableMultimap<String, String> queryParams;
 
     @Wither
@@ -52,5 +57,12 @@ public final class DefaultRequestArguments implements RequestArguments {
 
     @Wither
     Object body;
+
+    @Override
+    public <T> Optional<T> getAttribute(final Attribute<T> attribute) {
+        @SuppressWarnings("unchecked")
+        @Nullable final T value = (T) attributes.get(attribute);
+        return Optional.ofNullable(value);
+    }
 
 }

--- a/riptide-core/src/main/java/org/zalando/riptide/HeaderStage.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/HeaderStage.java
@@ -2,7 +2,6 @@ package org.zalando.riptide;
 
 import com.google.common.collect.Multimap;
 import org.apiguardian.api.API;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import java.time.OffsetDateTime;

--- a/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/RequestArguments.java
@@ -1,6 +1,7 @@
 package org.zalando.riptide;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import org.apiguardian.api.API;
 import org.springframework.http.HttpMethod;
@@ -10,6 +11,7 @@ import org.zalando.fauxpas.FauxPas;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apiguardian.api.API.Status.STABLE;
@@ -31,6 +33,10 @@ public interface RequestArguments {
 
     URI getUri();
 
+    <T> Optional<T> getAttribute(Attribute<T> attribute);
+
+    ImmutableMap<Attribute<?>, Object> getAttributes();
+
     ImmutableMultimap<String, String> getQueryParams();
 
     URI getRequestUri();
@@ -50,6 +56,8 @@ public interface RequestArguments {
     RequestArguments withUriVariables(@Nullable ImmutableList<Object> uriVariables);
 
     RequestArguments withUri(@Nullable URI uri);
+
+    RequestArguments withAttributes(@Nullable ImmutableMap<Attribute<?>, Object> attributes);
 
     RequestArguments withQueryParams(@Nullable ImmutableMultimap<String, String> queryParams);
 
@@ -105,8 +113,8 @@ public interface RequestArguments {
     }
 
     static RequestArguments create() {
-        return new DefaultRequestArguments(null, null, null, null, ImmutableList.of(), null, ImmutableMultimap.of(),
-                null, ImmutableMultimap.of(), null);
+        return new DefaultRequestArguments(null, null, null, null, ImmutableList.of(), null,
+                ImmutableMap.of(), ImmutableMultimap.of(), null, ImmutableMultimap.of(), null);
     }
 
 }

--- a/riptide-core/src/main/java/org/zalando/riptide/URIStage.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/URIStage.java
@@ -10,40 +10,40 @@ import static org.apiguardian.api.API.Status.STABLE;
 @API(status = STABLE)
 public interface URIStage {
 
-    QueryStage get(String uriTemplate, Object... urlVariables);
-    QueryStage get(URI uri);
-    QueryStage get();
+    AttributeStage get(String uriTemplate, Object... urlVariables);
+    AttributeStage get(URI uri);
+    AttributeStage get();
 
-    QueryStage head(String uriTemplate, Object... urlVariables);
-    QueryStage head(URI uri);
-    QueryStage head();
+    AttributeStage head(String uriTemplate, Object... urlVariables);
+    AttributeStage head(URI uri);
+    AttributeStage head();
 
-    QueryStage post(String uriTemplate, Object... urlVariables);
-    QueryStage post(URI uri);
-    QueryStage post();
+    AttributeStage post(String uriTemplate, Object... urlVariables);
+    AttributeStage post(URI uri);
+    AttributeStage post();
 
-    QueryStage put(String uriTemplate, Object... urlVariables);
-    QueryStage put(URI uri);
-    QueryStage put();
+    AttributeStage put(String uriTemplate, Object... urlVariables);
+    AttributeStage put(URI uri);
+    AttributeStage put();
 
-    QueryStage patch(String uriTemplate, Object... urlVariables);
-    QueryStage patch(URI uri);
-    QueryStage patch();
+    AttributeStage patch(String uriTemplate, Object... urlVariables);
+    AttributeStage patch(URI uri);
+    AttributeStage patch();
 
-    QueryStage delete(String uriTemplate, Object... urlVariables);
-    QueryStage delete(URI uri);
-    QueryStage delete();
+    AttributeStage delete(String uriTemplate, Object... urlVariables);
+    AttributeStage delete(URI uri);
+    AttributeStage delete();
 
-    QueryStage options(String uriTemplate, Object... urlVariables);
-    QueryStage options(URI uri);
-    QueryStage options();
+    AttributeStage options(String uriTemplate, Object... urlVariables);
+    AttributeStage options(URI uri);
+    AttributeStage options();
 
-    QueryStage trace(String uriTemplate, Object... urlVariables);
-    QueryStage trace(URI uri);
-    QueryStage trace();
+    AttributeStage trace(String uriTemplate, Object... urlVariables);
+    AttributeStage trace(URI uri);
+    AttributeStage trace();
 
-    QueryStage execute(HttpMethod method, String uriTemplate, Object... uriVariables);
-    QueryStage execute(HttpMethod method, URI uri);
-    QueryStage execute(HttpMethod method);
+    AttributeStage execute(HttpMethod method, String uriTemplate, Object... uriVariables);
+    AttributeStage execute(HttpMethod method, URI uri);
+    AttributeStage execute(HttpMethod method);
 
 }

--- a/riptide-core/src/test/java/org/zalando/riptide/AttributeTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/AttributeTest.java
@@ -1,0 +1,53 @@
+package org.zalando.riptide;
+
+import com.google.common.collect.ImmutableMultimap;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import static org.springframework.http.HttpStatus.Series.SUCCESSFUL;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.zalando.riptide.Bindings.on;
+import static org.zalando.riptide.Navigators.series;
+import static org.zalando.riptide.PassRoute.pass;
+
+final class AttributeTest {
+
+    private final Http unit;
+    private final MockRestServiceServer server;
+
+    private final Attribute<String> attribute = Attribute.generate();
+
+    AttributeTest() {
+        final MockSetup setup = new MockSetup();
+        this.server = setup.getServer();
+        this.unit = setup.getHttpBuilder()
+                .plugin(new Plugin() {
+                    @Override
+                    public RequestExecution beforeSend(final RequestExecution execution) {
+                        return arguments -> {
+                            final String secret = arguments.getAttribute(attribute).orElse("unknown");
+                            return execution.execute(arguments.withHeaders(ImmutableMultimap.of("Secret", secret)));
+                        };
+                    }
+                })
+                .build();
+    }
+
+    @Test
+    void shouldSendNoBody() {
+        server.expect(requestTo("https://api.example.com"))
+                .andExpect(header("Secret", "dXNlcjpzZWNyZXQK"))
+                .andRespond(withSuccess());
+
+        unit.trace("https://api.example.com")
+                .attribute(attribute, "dXNlcjpzZWNyZXQK")
+                .dispatch(series(),
+                        on(SUCCESSFUL).call(pass()))
+                .join();
+
+        server.verify();
+    }
+
+}

--- a/riptide-core/src/test/java/org/zalando/riptide/AttributeTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/AttributeTest.java
@@ -1,6 +1,7 @@
 package org.zalando.riptide;
 
 import com.google.common.collect.ImmutableMultimap;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.client.MockRestServiceServer;
 
@@ -35,8 +36,13 @@ final class AttributeTest {
                 .build();
     }
 
+    @AfterEach
+    void verify() {
+        server.verify();
+    }
+
     @Test
-    void shouldSendNoBody() {
+    void shouldPassAttribute() {
         server.expect(requestTo("https://api.example.com"))
                 .andExpect(header("Secret", "dXNlcjpzZWNyZXQK"))
                 .andRespond(withSuccess());
@@ -46,8 +52,18 @@ final class AttributeTest {
                 .dispatch(series(),
                         on(SUCCESSFUL).call(pass()))
                 .join();
+    }
 
-        server.verify();
+    @Test
+    void shouldNotPassAttribute() {
+        server.expect(requestTo("https://api.example.com"))
+                .andExpect(header("Secret", "unknown"))
+                .andRespond(withSuccess());
+
+        unit.trace("https://api.example.com")
+                .dispatch(series(),
+                        on(SUCCESSFUL).call(pass()))
+                .join();
     }
 
 }

--- a/riptide-core/src/test/java/org/zalando/riptide/ContentTypeDispatchTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/ContentTypeDispatchTest.java
@@ -12,8 +12,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpStatus.Series.SUCCESSFUL;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static org.springframework.http.MediaType.parseMediaType;

--- a/riptide-core/src/test/java/org/zalando/riptide/DefaultRequestArgumentsTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/DefaultRequestArgumentsTest.java
@@ -1,6 +1,7 @@
 package org.zalando.riptide;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import lombok.Value;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,6 +38,7 @@ final class DefaultRequestArgumentsTest {
                 new Assertion<>(RequestArguments::withUriTemplate, "/{id}", RequestArguments::getUriTemplate),
                 new Assertion<>(RequestArguments::withUriVariables, ImmutableList.of(123), RequestArguments::getUriVariables),
                 new Assertion<>(RequestArguments::withUri, URI.create("/123"), RequestArguments::getUri),
+                new Assertion<>(RequestArguments::withAttributes, ImmutableMap.of(Attribute.generate(), "foo"), RequestArguments::getAttributes),
                 new Assertion<>(RequestArguments::withQueryParams, ImmutableMultimap.of("k", "v"), RequestArguments::getQueryParams),
                 new Assertion<>(RequestArguments::withRequestUri, URI.create("https://api.example.com/123?k=v"), RequestArguments::getRequestUri),
                 new Assertion<>(RequestArguments::withHeaders, ImmutableMultimap.of("Secret", "true"), RequestArguments::getHeaders),

--- a/riptide-core/src/test/java/org/zalando/riptide/ForwardingClientHttpResponseTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/ForwardingClientHttpResponseTest.java
@@ -9,8 +9,8 @@ import java.io.IOException;
 
 import static com.google.common.io.ByteStreams.toByteArray;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/riptide-core/src/test/java/org/zalando/riptide/NavigatorsTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/NavigatorsTest.java
@@ -6,8 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatus.Series;
 import org.springframework.http.MediaType;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.zalando.riptide.Navigators.contentType;
 import static org.zalando.riptide.Navigators.reasonPhrase;
 import static org.zalando.riptide.Navigators.series;

--- a/riptide-core/src/test/java/org/zalando/riptide/RequesterImmutabilityTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/RequesterImmutabilityTest.java
@@ -1,7 +1,6 @@
 package org.zalando.riptide;
 
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.LinkedHashMultimap;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
@@ -24,9 +23,9 @@ final class RequesterImmutabilityTest {
         assertNotSame(original, original.accept(MediaType.ALL));
         assertNotSame(original, original.contentType(MediaType.APPLICATION_JSON));
         assertNotSame(original, original.header("header","value"));
-        assertNotSame(original, original.headers(ImmutableMultimap.of()));
+        assertNotSame(original, original.headers(ImmutableMultimap.of("header", "value")));
         assertNotSame(original, original.queryParam("p","v"));
-        assertNotSame(original, original.queryParams(LinkedHashMultimap.create()));
+        assertNotSame(original, original.queryParams(ImmutableMultimap.of("p", "v")));
         assertNotSame(original, original.ifMatch(""));
         assertNotSame(original, original.ifModifiedSince(OffsetDateTime.now()));
         assertNotSame(original, original.ifNoneMatch(""));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for type-safe attributes that can be provided at the call-site of an HTTP request and passed to plugins. Immediate intention is to pass the operation name for open tracing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prerequisite for #509 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
