### PR TITLE
Added Basic Auth support

### DIFF
--- a/riptide-auth/src/main/java/org/zalando/riptide/auth/BasicAuthorizationProvider.java
+++ b/riptide-auth/src/main/java/org/zalando/riptide/auth/BasicAuthorizationProvider.java
@@ -11,25 +11,22 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
  */
 public final class BasicAuthorizationProvider implements AuthorizationProvider {
 
-    private final Base64.Encoder base64 = Base64.getEncoder();
-
-    private final String username;
-    private final String password;
+    private final String authorization;
 
     public BasicAuthorizationProvider(final String username, final String password) {
         checkArgument(!username.contains(":"), "Username must not contain a colon");
         final CharsetEncoder encoder = ISO_8859_1.newEncoder();
         checkArgument(encoder.canEncode(username), "Username must be encoded in ISO-8859-1");
         checkArgument(encoder.canEncode(password), "Password must be encoded in ISO-8859-1");
-        this.username = username;
-        this.password = password;
+        final String credentials = username + ":" + password;
+        final Base64.Encoder base64 = Base64.getEncoder();
+        final byte[] bytes = credentials.getBytes(ISO_8859_1);
+        this.authorization = "Basic " + base64.encodeToString(bytes);
     }
 
     @Override
     public String get() {
-        final String credentials = username + ":" + password;
-        final byte[] bytes = credentials.getBytes(ISO_8859_1);
-        return "Basic " + base64.encodeToString(bytes);
+        return authorization;
     }
 
 }

--- a/riptide-auth/src/main/java/org/zalando/riptide/auth/BasicAuthorizationProvider.java
+++ b/riptide-auth/src/main/java/org/zalando/riptide/auth/BasicAuthorizationProvider.java
@@ -1,0 +1,35 @@
+package org.zalando.riptide.auth;
+
+import java.nio.charset.CharsetEncoder;
+import java.util.Base64;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
+/**
+ * @see <a href="https://tools.ietf.org/html/rfc7617">RFC 7617</a>
+ */
+public final class BasicAuthorizationProvider implements AuthorizationProvider {
+
+    private final Base64.Encoder base64 = Base64.getEncoder();
+
+    private final String username;
+    private final String password;
+
+    public BasicAuthorizationProvider(final String username, final String password) {
+        checkArgument(!username.contains(":"), "Username must not contain a colon");
+        final CharsetEncoder encoder = ISO_8859_1.newEncoder();
+        checkArgument(encoder.canEncode(username), "Username must be encoded in ISO-8859-1");
+        checkArgument(encoder.canEncode(password), "Password must be encoded in ISO-8859-1");
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public String get() {
+        final String credentials = username + ":" + password;
+        final byte[] bytes = credentials.getBytes(ISO_8859_1);
+        return "Basic " + base64.encodeToString(bytes);
+    }
+
+}

--- a/riptide-auth/src/test/java/org/zalando/riptide/auth/BasicAuthorizationProviderTest.java
+++ b/riptide-auth/src/test/java/org/zalando/riptide/auth/BasicAuthorizationProviderTest.java
@@ -1,0 +1,25 @@
+package org.zalando.riptide.auth;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class BasicAuthorizationProviderTest {
+
+    @Test
+    void shouldSupplyOAuthToken() throws IOException {
+        final AuthorizationProvider unit = new BasicAuthorizationProvider("username", "password");
+
+        assertEquals("Basic dXNlcm5hbWU6cGFzc3dvcmQ=", unit.get());
+    }
+
+    @Test
+    void shouldFailIfUsernameContainsColon() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new BasicAuthorizationProvider("user:name", ""));
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a `BasicAuthorizationProvider` in addition to the one we already have which is specific for Zalando's Platform IAM.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Until now the auth plugin is rather limited for non-Zalando users.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
