### PR TITLE
Enabled automatic registration of opentracing plugin for client

### DIFF
--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
@@ -377,7 +377,7 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
 
     private Optional<String> registerOpenTracingPlugin(final String id, final Client client) {
         if (client.getTracing().getEnabled()) {
-            registry.registerIfAbsent(id, OpenTracingPlugin.class, () -> {
+            final String pluginId = registry.registerIfAbsent(id, OpenTracingPlugin.class, () -> {
                 log.debug("Client [{}]: Registering [{}]", id, OpenTracingPlugin.class.getSimpleName());
                 return genericBeanDefinition(OpenTracingPluginFactory.class)
                         .setFactoryMethod("create")
@@ -385,6 +385,7 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
                         .addConstructorArgValue(client)
                         .addConstructorArgValue(registry.findRef(id, SpanDecorator.class).orElse(null));
             });
+            return Optional.of(pluginId);
         }
         return Optional.empty();
     }

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/PluginTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/PluginTest.java
@@ -21,6 +21,7 @@ import org.zalando.riptide.faults.FaultClassifier;
 import org.zalando.riptide.faults.TransientFaultPlugin;
 import org.zalando.riptide.logbook.LogbookPlugin;
 import org.zalando.riptide.metrics.MetricsPlugin;
+import org.zalando.riptide.opentracing.OpenTracingPlugin;
 import org.zalando.riptide.timeout.TimeoutPlugin;
 
 import java.lang.reflect.Field;
@@ -100,6 +101,7 @@ final class PluginTest {
                 instanceOf(Plugin.class), // internal plugin
                 instanceOf(Plugin.class), // internal plugin
                 instanceOf(MetricsPlugin.class),
+                instanceOf(OpenTracingPlugin.class),
                 instanceOf(FailsafePlugin.class))));
     }
 
@@ -130,6 +132,7 @@ final class PluginTest {
                 instanceOf(Plugin.class), // internal plugin
                 instanceOf(MetricsPlugin.class),
                 instanceOf(LogbookPlugin.class),
+                instanceOf(OpenTracingPlugin.class),
                 instanceOf(OriginalStackTracePlugin.class))));
     }
 


### PR DESCRIPTION
Not sure about the reasons, but even if configuration stated "enable tracing" the open tracing plugin was not properly registered in Spring starter configuration.

## Description
Enable registration of open tracing plugin via usual plugin registration way.

## Motivation and Context
To allow enabling of open tracing support via declarative configuration.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

Not really added tests, but fixed existing, since there was already configured test clients with enabled tracing in their config.