### PR TITLE
Cleanup of IdempotencyPlugin declaration

### DIFF
--- a/riptide-idempotency/src/main/java/org/zalando/riptide/idempotency/IdempotencyPlugin.java
+++ b/riptide-idempotency/src/main/java/org/zalando/riptide/idempotency/IdempotencyPlugin.java
@@ -1,0 +1,6 @@
+package org.zalando.riptide.idempotency;
+
+import org.zalando.riptide.Plugin;
+
+public class IdempotencyPlugin implements Plugin {
+}

--- a/riptide-idempotency/src/main/java/org/zalando/riptide/idempotency/IdempotencyPlugin.java
+++ b/riptide-idempotency/src/main/java/org/zalando/riptide/idempotency/IdempotencyPlugin.java
@@ -1,6 +1,0 @@
-package org.zalando.riptide.idempotency;
-
-import org.zalando.riptide.Plugin;
-
-public class IdempotencyPlugin implements Plugin {
-}

--- a/riptide-idempotency/src/main/resources/META-INF/services/org.zalando.riptide.Plugin
+++ b/riptide-idempotency/src/main/resources/META-INF/services/org.zalando.riptide.Plugin
@@ -1,1 +1,0 @@
-org.zalando.riptide.idempotency.IdempotencyPlugin

--- a/riptide-idempotency/src/test/java/org/zalando/riptide/idempotency/IdempotencyPluginTest.java
+++ b/riptide-idempotency/src/test/java/org/zalando/riptide/idempotency/IdempotencyPluginTest.java
@@ -1,0 +1,24 @@
+package org.zalando.riptide.idempotency;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.zalando.riptide.Http;
+
+import java.util.ServiceConfigurationError;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+final class IdempotencyPluginTest {
+    @Test
+    void testHttpCreation() {
+        try {
+            Http.builder()
+                .executor(Executors.newCachedThreadPool())
+                .requestFactory(new HttpComponentsClientHttpRequestFactory())
+                .build();
+        } catch (ServiceConfigurationError e) {
+            fail(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Cleanup of IdempotencyPlugin declaration

## Motivation and Context
As soon as I got riptide-idempotence in my class path, I can not create simple http client without specifying plugins any more. Default plugin resolver see plugin declaration in META-INF.services but fails to find actual class, which leads to ```ServiceConfigurationException: org.zalando.riptide.Plugin: Provider org.zalando.riptide.idempotency.IdempotencyPlugin not found.```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.