### PR TITLE
Inject tracer by bean reference instead of name

### DIFF
--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Registry.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Registry.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import static org.zalando.riptide.autoconfigure.Name.name;
 
 @AllArgsConstructor
@@ -46,11 +48,11 @@ final class Registry {
         });
     }
 
-    Optional<BeanReference> findRef(final String id, final Class<?>... types) {
+    Optional<BeanReference> findRef(@Nullable final String id, final Class<?>... types) {
         return find(id, types).map(Registry::ref);
     }
 
-    Optional<String> find(final String id, final Class<?>... types) {
+    Optional<String> find(@Nullable final String id, final Class<?>... types) {
         return find(name(id, types));
     }
 

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/OpenTracingTestAutoConfiguration.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/OpenTracingTestAutoConfiguration.java
@@ -12,7 +12,7 @@ import org.zalando.tracer.autoconfigure.TracerAutoConfiguration;
 public class OpenTracingTestAutoConfiguration {
 
     @Bean
-    public Tracer tracer() {
+    public Tracer tracerBean() {
         return new MockTracer();
     }
 


### PR DESCRIPTION
## Description
Inject tracer by bean reference instead of name

## Motivation and Context
Currently tracer bean is injected by name. This leads to incompatibility issues with tracing-lightstep-spring-boot-starter > 0.1.5
Instead of relying on bean name for plugin registration, I've changed to loading by type.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.