### PR TITLE
Added proper support for stack and message span tags

### DIFF
--- a/riptide-opentracing/README.md
+++ b/riptide-opentracing/README.md
@@ -76,11 +76,13 @@ The following tags/logs are supported out of the box:
 | `error`              | `ErrorSpanDecorator`           | `false`                           |
 | `error.kind` (log)   | `ErrorSpanDecorator`           | `SocketTimeoutException`          |
 | `error.object` (log) | `ErrorSpanDecorator`           | (exception instance)              |
+| `message` (log)      | `ErrorMessageSpanDecorator`    | `Connection timed out`            |
+| `stack` (log)        | `ErrorStackSpanDecorator`      | `SocketTimeoutException at [...]` |
 | `retry`              | `RetrySpanDecorator`           | `true`                            |
 | `retry_number` (log) | `RetrySpanDecorator`           | `3`                               |
 | `*`                  | `CallSiteSpanDecorator`        | `admin=true`                      |
 | `*`                  | `StaticTagSpanDecorator`       | `aws.region=eu-central-1`         |
-| `*`                  | `UriVariablesTagSpanDecorator` | user_id=me                        |
+| `*`                  | `UriVariablesTagSpanDecorator` | `user_id=me`                      |
 
 ### Notice
 

--- a/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/OpenTracingPlugin.java
+++ b/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/OpenTracingPlugin.java
@@ -17,6 +17,7 @@ import org.zalando.riptide.RequestExecution;
 import org.zalando.riptide.opentracing.span.CallSiteSpanDecorator;
 import org.zalando.riptide.opentracing.span.ComponentSpanDecorator;
 import org.zalando.riptide.opentracing.span.ErrorSpanDecorator;
+import org.zalando.riptide.opentracing.span.ErrorStackSpanDecorator;
 import org.zalando.riptide.opentracing.span.HttpMethodSpanDecorator;
 import org.zalando.riptide.opentracing.span.HttpPathSpanDecorator;
 import org.zalando.riptide.opentracing.span.HttpStatusCodeSpanDecorator;
@@ -83,6 +84,7 @@ public final class OpenTracingPlugin implements Plugin {
                         new CallSiteSpanDecorator(),
                         new ComponentSpanDecorator(),
                         new ErrorSpanDecorator(),
+                        new ErrorStackSpanDecorator(),
                         new HttpMethodSpanDecorator(),
                         new HttpPathSpanDecorator(),
                         new HttpStatusCodeSpanDecorator(),

--- a/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/span/ErrorMessageSpanDecorator.java
+++ b/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/span/ErrorMessageSpanDecorator.java
@@ -1,0 +1,21 @@
+package org.zalando.riptide.opentracing.span;
+
+import io.opentracing.Span;
+import io.opentracing.log.Fields;
+import org.zalando.riptide.RequestArguments;
+
+import static java.util.Collections.singletonMap;
+
+/**
+ * Sets the <code>message</code> span log.
+ *
+ * @see <a href="https://opentracing.io/specification/conventions/#log-fields-table">Standard Log Fields</a>
+ */
+public final class ErrorMessageSpanDecorator implements SpanDecorator {
+
+    @Override
+    public void onError(final Span span, final RequestArguments arguments, final Throwable error) {
+        span.log(singletonMap(Fields.MESSAGE, error.getMessage()));
+    }
+
+}

--- a/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/span/ErrorSpanDecorator.java
+++ b/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/span/ErrorSpanDecorator.java
@@ -1,6 +1,5 @@
 package org.zalando.riptide.opentracing.span;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import io.opentracing.Span;
 import io.opentracing.log.Fields;
@@ -30,9 +29,7 @@ public final class ErrorSpanDecorator implements SpanDecorator {
         span.setTag(Tags.ERROR, true);
         span.log(ImmutableMap.of(
                 Fields.ERROR_KIND, error.getClass().getSimpleName(),
-                Fields.ERROR_OBJECT, error,
-                Fields.MESSAGE, error.getMessage(),
-                Fields.STACK, Throwables.getStackTraceAsString(error)
+                Fields.ERROR_OBJECT, error
         ));
     }
 

--- a/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/span/ErrorStackSpanDecorator.java
+++ b/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/span/ErrorStackSpanDecorator.java
@@ -1,0 +1,76 @@
+package org.zalando.riptide.opentracing.span;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opentracing.Span;
+import io.opentracing.log.Fields;
+import org.zalando.riptide.RequestArguments;
+
+import javax.annotation.Nullable;
+import java.io.PrintWriter;
+
+import static java.util.Collections.singletonMap;
+import static org.zalando.riptide.OriginalStackTracePlugin.STACK;
+
+/**
+ * Sets the <code>stack</code> span log.
+ *
+ * @see <a href="https://opentracing.io/specification/conventions/#log-fields-table">Standard Log Fields</a>
+ */
+public final class ErrorStackSpanDecorator implements SpanDecorator {
+
+    private final StackRenderer renderer = new StackRenderer();
+
+    @Override
+    public void onError(final Span span, final RequestArguments arguments, final Throwable error) {
+        final String stack = arguments.getAttribute(STACK)
+                .map(original -> renderer.render(error, original.get()))
+                .orElseGet(() -> renderer.render(error));
+
+        span.log(singletonMap(Fields.STACK, stack));
+    }
+
+    @VisibleForTesting
+    static final class StackRenderer {
+
+        private final StackTraceElement[] empty = new StackTraceElement[0];
+
+        String render(final Throwable throwable) {
+            return render(throwable, empty);
+        }
+
+        /**
+         * @see Throwable#printStackTrace(PrintWriter)
+         * @param throwable the error
+         */
+        String render(final Throwable throwable, final StackTraceElement[] original) {
+            final StringBuilder output = new StringBuilder(2048);
+            printStackTrace(throwable, original, output);
+            return output.toString();
+        }
+
+        private void printStackTrace(final Throwable throwable, final StringBuilder output) {
+            printStackTrace(throwable, empty, output);
+        }
+
+        private void printStackTrace(final Throwable throwable, final StackTraceElement[] original, final StringBuilder output) {
+            output.append(throwable).append("\n");
+            print(throwable.getStackTrace(), output);
+            print(original, output);
+
+            @Nullable final Throwable cause = throwable.getCause();
+
+            if (cause != null) {
+                output.append("Caused by: ");
+                printStackTrace(cause, output);
+            }
+        }
+
+        private void print(final StackTraceElement[] elements, final StringBuilder output) {
+            for (final StackTraceElement element : elements) {
+                output.append("\tat ").append(element.toString()).append("\n");
+            }
+        }
+
+    }
+
+}

--- a/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/span/package-info.java
+++ b/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/span/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.zalando.riptide.opentracing.span;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/riptide-opentracing/src/test/java/org/zalando/riptide/opentracing/span/StackRendererTest.java
+++ b/riptide-opentracing/src/test/java/org/zalando/riptide/opentracing/span/StackRendererTest.java
@@ -1,0 +1,43 @@
+package org.zalando.riptide.opentracing.span;
+
+import org.junit.jupiter.api.Test;
+import org.zalando.riptide.opentracing.span.ErrorStackSpanDecorator.StackRenderer;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+class StackRendererTest {
+
+    private final StackRenderer unit = new StackRenderer();
+
+    @Test
+    void shouldRender() {
+        final String stack = unit.render(new IOException("Timeout"));
+
+        assertThat(stack, containsString("java.io.IOException: Timeout"));
+        assertThat(stack, not(containsString("Caused by:")));
+    }
+
+    @Test
+    void shouldRenderWithOriginalStackTrace() {
+        final String stack = unit.render(new IOException("Timeout"), new StackTraceElement[] {
+                new StackTraceElement("org.zalando.riptide.opentracing.MyClass", "test", "MyClass.java", 17)
+        });
+
+        assertThat(stack, containsString("java.io.IOException: Timeout"));
+        assertThat(stack, containsString("\tat org.zalando.riptide.opentracing.MyClass.test(MyClass.java:17)"));
+    }
+
+    @Test
+    void shouldRenderWithCause() {
+        final String stack = unit.render(new IOException("Timeout", new SocketTimeoutException("Read timed out")));
+
+        assertThat(stack, containsString("java.io.IOException: Timeout"));
+        assertThat(stack, containsString("Caused by: java.net.SocketTimeoutException: Read timed out"));
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added new span decorators for `stack` and `message` log fields:
https://github.com/opentracing/specification/blob/master/semantic_conventions.md

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Consistency with internal OpenTracing semantic conventions. @pc-alves

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
