### PR TITLE
Document tracer bean requirements

### DIFF
--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -186,7 +186,7 @@ Required when `logging` is enabled.
 
 #### [Tracer](https://github.com/zalando/tracer) integration
 
-Required when `tracing` is enabled. Requires a `io.opentracing.Tracer` bean named `tracer` in the context.
+Required when `tracing` is enabled.
 
 ```xml
 <dependency>

--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -186,6 +186,8 @@ Required when `logging` is enabled.
 
 #### [Tracer](https://github.com/zalando/tracer) integration
 
+Required when `tracing` is enabled. Requires a `io.opentracing.Tracer` bean named `tracer` in the context.
+
 ```xml
 <dependency>
     <groupId>org.zalando</groupId>


### PR DESCRIPTION
## Description

The starter is failing with active `tracing` without a bean called `tracer`.

## Motivation and Context

Additional documentation may help others to configure their context correctly, as long as discovery is based on a name.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
