### PR TITLE
Made reference to httpclient-cache optional

### DIFF
--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
@@ -600,7 +600,7 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
                     .addConstructorArgValue(configureFirstRequestInterceptors(id, client))
                     .addConstructorArgReference(connectionManager)
                     .addConstructorArgValue(registry.findRef(id, HttpClientCustomizer.class).orElse(null))
-                    .addConstructorArgValue(registry.findRef(id, HttpCacheStorage.class).orElse(null))
+                    .addConstructorArgValue(findCacheStorageReference(id, client).orElse(null))
                     .setDestroyMethodName("close");
         });
     }
@@ -614,6 +614,14 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
         }
 
         return interceptors;
+    }
+
+    private Optional<BeanReference> findCacheStorageReference(final String id, final Client client) {
+        if (client.getCaching().getEnabled()) {
+            return registry.findRef(id, HttpCacheStorage.class);
+        } else {
+            return Optional.empty();
+        }
     }
 
 }

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/HttpClientFactory.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/HttpClientFactory.java
@@ -73,7 +73,7 @@ final class HttpClientFactory {
             final List<HttpRequestInterceptor> firstRequestInterceptors,
             final HttpClientConnectionManager connectionManager,
             @Nullable final HttpClientCustomizer customizer,
-            @Nullable final HttpCacheStorage cacheStorage) {
+            @Nullable final Object cacheStorage) {
 
         final Caching caching = client.getCaching();
         final HttpClientBuilder builder = caching.getEnabled() ?
@@ -97,8 +97,8 @@ final class HttpClientFactory {
         return builder.build();
     }
 
-    private static CachingHttpClientBuilder configureCaching(final Caching caching,
-            @Nullable final HttpCacheStorage cacheStorage) {
+    private static HttpClientBuilder configureCaching(final Caching caching,
+            @Nullable final Object cacheStorage) {
         final Heuristic heuristic = caching.getHeuristic();
 
         final CacheConfig.Builder config = CacheConfig.custom()
@@ -114,7 +114,7 @@ final class HttpClientFactory {
 
         return CachingHttpClients.custom()
                 .setCacheConfig(config.build())
-                .setHttpCacheStorage(cacheStorage)
+                .setHttpCacheStorage((HttpCacheStorage)cacheStorage)
                 .setCacheDir(Optional.ofNullable(caching.getDirectory())
                         .map(Path::toFile)
                         .orElse(null));


### PR DESCRIPTION
## Description
Proposal for fix of #714

## Motivation and Context
At the moment httpclient-cache is hard dependency, even if it's not declared explicitly in pom as such.
This fix intent to make riptide independent from this dependency if caching is not enabled.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.