### PR TITLE
Added SPI support for SpanDecorators

### DIFF
--- a/riptide-opentracing/README.md
+++ b/riptide-opentracing/README.md
@@ -84,6 +84,8 @@ The following tags/logs are supported out of the box:
 | `*`                  | `StaticTagSpanDecorator`       | `aws.region=eu-central-1`         |
 | `*`                  | `UriVariablesTagSpanDecorator` | `user_id=me`                      |
 
+Custom `SpanDecorator` implementations that are registered using [Java's Service Provider Interface](https://docs.oracle.com/javase/tutorial/ext/basics/spi.html) mechanism will be picked up automatically by default.
+
 ### Notice
 
 **Be aware**: The `http.url` tag is disabled by default because the full request URI may contain

--- a/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/OpenTracingPlugin.java
+++ b/riptide-opentracing/src/main/java/org/zalando/riptide/opentracing/OpenTracingPlugin.java
@@ -34,8 +34,10 @@ import java.util.concurrent.CompletionException;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
+import static com.google.common.collect.ImmutableList.copyOf;
 import static io.opentracing.propagation.Format.Builtin.HTTP_HEADERS;
 import static java.util.Objects.nonNull;
+import static java.util.ServiceLoader.load;
 import static lombok.AccessLevel.PRIVATE;
 
 @AllArgsConstructor(access = PRIVATE)
@@ -93,7 +95,8 @@ public final class OpenTracingPlugin implements Plugin {
                         new HttpPathSpanDecorator(),
                         new HttpStatusCodeSpanDecorator(),
                         new PeerSpanDecorator(),
-                        new SpanKindSpanDecorator()
+                        new SpanKindSpanDecorator(),
+                        SpanDecorator.composite(copyOf(load(SpanDecorator.class)))
                 ));
     }
 

--- a/riptide-opentracing/src/test/java/org/zalando/riptide/opentracing/OpenTracingPluginTest.java
+++ b/riptide-opentracing/src/test/java/org/zalando/riptide/opentracing/OpenTracingPluginTest.java
@@ -102,6 +102,7 @@ final class OpenTracingPluginTest {
         assertThat(child.tags(), hasEntry("test", "true"));
         assertThat(child.tags(), hasEntry("test.environment", "JUnit"));
         assertThat(child.tags(), hasEntry("user", "me"));
+        assertThat(child.tags(), hasEntry("spi", true));
 
         // not active by default
         assertThat(child.tags(), not(hasKey("http.url")));
@@ -146,6 +147,7 @@ final class OpenTracingPluginTest {
         assertThat(child.tags(), hasEntry("error", true));
         assertThat(child.tags(), hasEntry("test", "true"));
         assertThat(child.tags(), hasEntry("test.environment", "JUnit"));
+        assertThat(child.tags(), hasEntry("spi", true));
 
         // since we didn't use a uri template
         assertThat(child.tags(), not(hasKey("http.path")));

--- a/riptide-opentracing/src/test/java/org/zalando/riptide/opentracing/span/TestSpanDecorator.java
+++ b/riptide-opentracing/src/test/java/org/zalando/riptide/opentracing/span/TestSpanDecorator.java
@@ -1,0 +1,13 @@
+package org.zalando.riptide.opentracing.span;
+
+import io.opentracing.Span;
+import org.zalando.riptide.RequestArguments;
+
+public final class TestSpanDecorator implements SpanDecorator {
+
+    @Override
+    public void onRequest(final Span span, final RequestArguments arguments) {
+        span.setTag("spi", true);
+    }
+
+}

--- a/riptide-opentracing/src/test/resources/META-INF/services/org.zalando.riptide.opentracing.span.SpanDecorator
+++ b/riptide-opentracing/src/test/resources/META-INF/services/org.zalando.riptide.opentracing.span.SpanDecorator
@@ -1,0 +1,1 @@
+org.zalando.riptide.opentracing.span.TestSpanDecorator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
By default span decorators are also picked up via the service loader.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users that prefer to register custom `SpanDecorators` using the service provider interface (ServiceLoader) now can do that, rather than registering them by hand.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
