### PR TITLE
Avoid dependency to CachingHttpClientBuilder

### DIFF
--- a/riptide-spring-boot-autoconfigure/pom.xml
+++ b/riptide-spring-boot-autoconfigure/pom.xml
@@ -261,10 +261,39 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
                 <configuration>
                     <perCoreThreadCount>false</perCoreThreadCount>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>full-classpath</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*Test.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/NoCachingTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>missing-httpcache</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/NoCachingTest.java</include>
+                            </includes>
+                            <classpathDependencyExcludes>org.apache.httpcomponents:httpclient-cache</classpathDependencyExcludes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/NoCachingTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/NoCachingTest.java
@@ -1,0 +1,16 @@
+package org.zalando.riptide.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+final class NoCachingTest {
+    @Test
+    void shouldReadClassDefinitionWithoutCache() {
+        Method[] methods = ReflectionUtils.getUniqueDeclaredMethods(HttpClientFactory.class);
+        assertNotNull(methods);
+    }
+}


### PR DESCRIPTION
## Description
Second try to address issue #714 

## Motivation and Context
Seems even if the #716 was enough to trick IDEA into loading riptide successfully, but that fix was not complete in case running the application from the maven. I've added simple test to verify behaviour. This requires the new surefire configuration to manipulate class path around for test execution. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.