### PR TITLE
Changed packaging of starter

### DIFF
--- a/riptide-spring-boot-starter/pom.xml
+++ b/riptide-spring-boot-starter/pom.xml
@@ -21,6 +21,15 @@
             <artifactId>riptide-spring-boot-autoconfigure</artifactId>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>
-

--- a/riptide-spring-boot-starter/pom.xml
+++ b/riptide-spring-boot-starter/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>riptide-spring-boot-starter</artifactId>
-    <packaging>pom</packaging>
 
     <name>Riptide: Spring Boot Starter</name>
     <description>Client side response routing</description>


### PR DESCRIPTION
## Description

Changed packaging of spring starter to jar instead of pom to avoid 404 errors during following instructions from README

## Motivation and Context

Starters by default in spring world provided as empty jar files to make simple `<dependency>...` declaration to use them. With packaging type `pom` it's required to specify dependency as following.
```
<dependency>
    <groupId>org.zalando</groupId>
    <artifactId>riptide-spring-boot-starter</artifactId>
    <version>3.0.0-RC.3</version>
    <type>pom</type>
</dependency>
```

Current instructions in README omit mention of `type` which leads to 404 errors during jar dependency download. 

Check released contents https://repo1.maven.org/maven2/org/zalando/riptide-spring-boot-starter/3.0.0-RC.3/ vs https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-web/2.1.7.RELEASE/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.