### PR TITLE
Removes hard dependency of `riptide-micrometer` to `riptide-failsafe`

### DIFF
--- a/riptide-spring-boot-autoconfigure/pom.xml
+++ b/riptide-spring-boot-autoconfigure/pom.xml
@@ -272,6 +272,7 @@
                             </includes>
                             <excludes>
                                 <exclude>**/NoCachingTest.java</exclude>
+                                <exclude>**/NoRiptideFailsafeTest.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -286,6 +287,19 @@
                                 <include>**/NoCachingTest.java</include>
                             </includes>
                             <classpathDependencyExcludes>org.apache.httpcomponents:httpclient-cache</classpathDependencyExcludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>missing-riptide-failsafe</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/NoRiptideFailsafeTest.java</include>
+                            </includes>
+                            <classpathDependencyExcludes>org.zalando:riptide-failsafe</classpathDependencyExcludes>
                         </configuration>
                     </execution>
                 </executions>

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
@@ -540,12 +540,12 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
     private String registerRetryListener(final String id, final Client client) {
         return registry.registerIfAbsent(id, RetryListener.class, () -> {
             if (client.getMetrics().getEnabled()) {
-                return genericBeanDefinition(MicrometerPluginFactory.class)
+                return genericBeanDefinition(MicrometerFailsafeFactory.class)
                         .setFactoryMethod("createRetryListener")
                         .addConstructorArgValue(METER_REGISTRY_REF)
                         .addConstructorArgValue(ImmutableList.of(clientId(id)));
             } else {
-                return genericBeanDefinition(MicrometerPluginFactory.class)
+                return genericBeanDefinition(MicrometerFailsafeFactory.class)
                         .setFactoryMethod("getDefaultRetryListener");
             }
         });
@@ -554,12 +554,12 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
     private String registerCircuitBreakerListener(final String id, final Client client) {
         return registry.registerIfAbsent(id, CircuitBreakerListener.class, () -> {
             if (client.getMetrics().getEnabled()) {
-                return genericBeanDefinition(MicrometerPluginFactory.class)
+                return genericBeanDefinition(MicrometerFailsafeFactory.class)
                         .setFactoryMethod("createCircuitBreakerListener")
                         .addConstructorArgValue(METER_REGISTRY_REF)
                         .addConstructorArgValue(ImmutableList.of(clientId(id), clientName(id, client)));
             } else {
-                return genericBeanDefinition(MicrometerPluginFactory.class)
+                return genericBeanDefinition(MicrometerFailsafeFactory.class)
                         .setFactoryMethod("getDefaultCircuitBreakerListener");
             }
         });

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/MicrometerFailsafeFactory.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/MicrometerFailsafeFactory.java
@@ -1,0 +1,39 @@
+package org.zalando.riptide.autoconfigure;
+
+import com.google.common.collect.ImmutableList;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import org.zalando.riptide.failsafe.CircuitBreakerListener;
+import org.zalando.riptide.failsafe.CompositeRetryListener;
+import org.zalando.riptide.failsafe.LoggingRetryListener;
+import org.zalando.riptide.failsafe.RetryListener;
+import org.zalando.riptide.failsafe.metrics.MetricsCircuitBreakerListener;
+import org.zalando.riptide.failsafe.metrics.MetricsRetryListener;
+
+final class MicrometerFailsafeFactory {
+
+    private MicrometerFailsafeFactory() {
+
+    }
+
+    public static CircuitBreakerListener createCircuitBreakerListener(final MeterRegistry registry,
+            final ImmutableList<Tag> defaultTags) {
+        return new MetricsCircuitBreakerListener(registry).withDefaultTags(defaultTags);
+    }
+
+    public static CircuitBreakerListener getDefaultCircuitBreakerListener() {
+        return CircuitBreakerListener.DEFAULT;
+    }
+
+    public static RetryListener createRetryListener(final MeterRegistry registry,
+            final ImmutableList<Tag> defaultTags) {
+        return new CompositeRetryListener(
+                new MetricsRetryListener(registry).withDefaultTags(defaultTags),
+                new LoggingRetryListener()
+        );
+    }
+
+    public static RetryListener getDefaultRetryListener() {
+        return new LoggingRetryListener();
+    }
+}

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/MicrometerPluginFactory.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/MicrometerPluginFactory.java
@@ -4,12 +4,6 @@ import com.google.common.collect.ImmutableList;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import org.zalando.riptide.Plugin;
-import org.zalando.riptide.failsafe.CircuitBreakerListener;
-import org.zalando.riptide.failsafe.CompositeRetryListener;
-import org.zalando.riptide.failsafe.LoggingRetryListener;
-import org.zalando.riptide.failsafe.RetryListener;
-import org.zalando.riptide.failsafe.metrics.MetricsCircuitBreakerListener;
-import org.zalando.riptide.failsafe.metrics.MetricsRetryListener;
 import org.zalando.riptide.micrometer.MicrometerPlugin;
 
 final class MicrometerPluginFactory {
@@ -21,26 +15,5 @@ final class MicrometerPluginFactory {
     public static Plugin createMicrometerPlugin(final MeterRegistry registry,
             final ImmutableList<Tag> tags) {
         return new MicrometerPlugin(registry).withDefaultTags(tags);
-    }
-
-    public static CircuitBreakerListener createCircuitBreakerListener(final MeterRegistry registry,
-            final ImmutableList<Tag> defaultTags) {
-        return new MetricsCircuitBreakerListener(registry).withDefaultTags(defaultTags);
-    }
-
-    public static CircuitBreakerListener getDefaultCircuitBreakerListener() {
-        return CircuitBreakerListener.DEFAULT;
-    }
-
-    public static RetryListener createRetryListener(final MeterRegistry registry,
-            final ImmutableList<Tag> defaultTags) {
-        return new CompositeRetryListener(
-                new MetricsRetryListener(registry).withDefaultTags(defaultTags),
-                new LoggingRetryListener()
-        );
-    }
-
-    public static RetryListener getDefaultRetryListener() {
-        return new LoggingRetryListener();
     }
 }

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/NoRiptideFailsafeTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/NoRiptideFailsafeTest.java
@@ -1,0 +1,16 @@
+package org.zalando.riptide.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+final class NoRiptideFailsafeTest {
+    @Test
+    void shouldReadClassDefinitionWithoutFailsafePlugin() {
+        Method[] methods = ReflectionUtils.getUniqueDeclaredMethods(MicrometerPluginFactory.class);
+        assertNotNull(methods);
+    }
+}


### PR DESCRIPTION
Removes hard dependency of `riptide-micrometer` to `riptide-failsafe` in Spring auto configuration.

Fixes gh-774

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
