### PR TITLE
Fix test failing on Windows

### DIFF
--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/DefaultingTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/DefaultingTest.java
@@ -112,7 +112,7 @@ final class DefaultingTest {
 
         assertThat(actual.getEnabled(), is(false));
         assertThat(actual.getShared(), is(true));
-        assertThat(actual.getDirectory(), hasToString("/var/cache/http"));
+        assertThat(actual.getDirectory(), is(Paths.get("/var/cache/http")));
         assertThat(actual.getMaxObjectSize(), is(4096));
         assertThat(actual.getMaxCacheEntries(), is(100));
         assertThat(actual.getHeuristic().getEnabled(), is(false));


### PR DESCRIPTION
Currently, the changed test fails on Windows, because toString outputs `\var\cache\http` rather than `/var/cache/http`.

## Motivation and Context
Allow tests to run on Windows.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
