### PR TITLE
Refactored thread/connection pool metrics

### DIFF
--- a/riptide-httpclient/src/main/java/org/zalando/riptide/httpclient/metrics/HttpConnectionPoolMetrics.java
+++ b/riptide-httpclient/src/main/java/org/zalando/riptide/httpclient/metrics/HttpConnectionPoolMetrics.java
@@ -5,22 +5,29 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import lombok.AllArgsConstructor;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.pool.PoolStats;
 import org.apiguardian.api.API;
 
-import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
+import static com.google.common.collect.ImmutableList.copyOf;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static lombok.AccessLevel.PRIVATE;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
-import static org.apiguardian.api.API.Status.INTERNAL;
 
 @API(status = EXPERIMENTAL)
+@AllArgsConstructor(access = PRIVATE)
 public final class HttpConnectionPoolMetrics implements MeterBinder {
 
-    private final PoolingHttpClientConnectionManager manager;
+    private static final String CONNECTIONS = "connections";
+    private static final String REQUESTS = "requests";
+
+    // since getTotalStats locks the connection pool, we cache the value for a minute to reduce possible contention
+    private final Supplier<PoolStats> stats;
     private final String metricName;
     private final ImmutableList<Tag> defaultTags;
 
@@ -28,42 +35,65 @@ public final class HttpConnectionPoolMetrics implements MeterBinder {
         this(manager, "http.client.connections", ImmutableList.of());
     }
 
-    @API(status = INTERNAL)
-    HttpConnectionPoolMetrics(final PoolingHttpClientConnectionManager manager,
-            final String metricName, final ImmutableList<Tag> defaultTags) {
-        this.manager = manager;
-        this.metricName = metricName;
-        this.defaultTags = defaultTags;
+    private HttpConnectionPoolMetrics(
+            final PoolingHttpClientConnectionManager manager,
+            final String metricName,
+            final ImmutableList<Tag> defaultTags) {
+        this(memoizeWithExpiration(manager::getTotalStats, 1, MINUTES),
+                metricName, defaultTags);
     }
 
     public HttpConnectionPoolMetrics withMetricName(final String metricName) {
-        return new HttpConnectionPoolMetrics(manager, metricName, defaultTags);
+        return new HttpConnectionPoolMetrics(stats, metricName, defaultTags);
     }
 
     public HttpConnectionPoolMetrics withDefaultTags(final Tag... defaultTags) {
-        return withDefaultTags(ImmutableList.copyOf(defaultTags));
+        return withDefaultTags(copyOf(defaultTags));
     }
 
     public HttpConnectionPoolMetrics withDefaultTags(final Iterable<Tag> defaultTags) {
-        return new HttpConnectionPoolMetrics(manager, metricName, ImmutableList.copyOf(defaultTags));
+        return new HttpConnectionPoolMetrics(stats, metricName, copyOf(defaultTags));
     }
 
     @Override
     public void bindTo(final MeterRegistry registry) {
-        // since getTotalStats locks the connection pool, we cache the value for a minute to reduce possible contention
-        final Supplier<PoolStats> stats = memoizeWithExpiration(manager::getTotalStats, 1, MINUTES);
+        gauge("available", PoolStats::getAvailable)
+                .description("The number idle connections")
+                .baseUnit(CONNECTIONS)
+                .register(registry);
 
-        gauge(registry, "available", stats, PoolStats::getAvailable);
-        gauge(registry, "leased", stats, PoolStats::getLeased);
-        gauge(registry, "max", stats, PoolStats::getMax);
-        gauge(registry, "pending", stats, PoolStats::getPending);
+        gauge("leased", PoolStats::getLeased)
+                .description("The number of connections that are actively executing requests")
+                .baseUnit(CONNECTIONS)
+                .register(registry);
+
+        gauge("total", stats -> stats.getAvailable() + stats.getLeased())
+                .description("The number of connections that are currently in the pool")
+                .baseUnit(CONNECTIONS)
+                .register(registry);
+
+        gauge("min", stats -> 0)
+                .description("The minimum number of connections in the pool")
+                .baseUnit(CONNECTIONS)
+                .register(registry);
+
+        gauge("max", PoolStats::getMax)
+                .description("The maximum number of connections in the pool")
+                .baseUnit(CONNECTIONS)
+                .register(registry);
+
+        gauge("queued", PoolStats::getPending)
+                .description("The number of queued connection lease requests")
+                .baseUnit(REQUESTS)
+                .register(registry);
     }
 
-    private void gauge(final MeterRegistry registry, final String name, final Supplier<PoolStats> stats,
-            final Function<PoolStats, Number> function) {
-        Gauge.builder(metricName + "." + name, () -> function.apply(stats.get()))
-                .tags(defaultTags)
-                .register(registry);
+    private Gauge.Builder<Supplier<Number>> gauge(
+            final String name,
+            final ToIntFunction<PoolStats> function) {
+
+        return Gauge.builder(metricName + "." + name, () -> function.applyAsInt(stats.get()))
+                .tags(defaultTags);
     }
 
 }

--- a/riptide-httpclient/src/test/java/org/zalando/riptide/httpclient/metrics/HttpConnectionPoolMetricsTest.java
+++ b/riptide-httpclient/src/test/java/org/zalando/riptide/httpclient/metrics/HttpConnectionPoolMetricsTest.java
@@ -43,7 +43,7 @@ final class HttpConnectionPoolMetricsTest {
             .baseUrl(driver.getBaseUrl())
             .build();
 
-    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final MeterRegistry registry = new SimpleMeterRegistry();
 
     @AfterEach
     void closeClient() throws IOException {
@@ -55,7 +55,7 @@ final class HttpConnectionPoolMetricsTest {
         new HttpConnectionPoolMetrics(connectionManager)
                 .withMetricName("connection-pool")
                 .withDefaultTags(Tag.of("version", "1"))
-                .bindTo(meterRegistry);
+                .bindTo(registry);
 
         driver.addExpectation(onRequestTo("/"), giveEmptyResponse());
 
@@ -63,12 +63,14 @@ final class HttpConnectionPoolMetricsTest {
 
         assertThat(gauge("connection-pool.available").value(), is(1.0));
         assertThat(gauge("connection-pool.leased").value(), is(0.0));
+        assertThat(gauge("connection-pool.total").value(), is(1.0));
+        assertThat(gauge("connection-pool.min").value(), is(0.0));
         assertThat(gauge("connection-pool.max").value(), is(20.0));
-        assertThat(gauge("connection-pool.pending").value(), is(0.0));
+        assertThat(gauge("connection-pool.queued").value(), is(0.0));
     }
 
     private Gauge gauge(final String name) {
-        return meterRegistry.find(name).tag("version", "1").gauge();
+        return registry.find(name).tag("version", "1").gauge();
     }
 
 }

--- a/riptide-micrometer/src/main/java/org/zalando/riptide/micrometer/ThreadPoolMetrics.java
+++ b/riptide-micrometer/src/main/java/org/zalando/riptide/micrometer/ThreadPoolMetrics.java
@@ -1,0 +1,84 @@
+package org.zalando.riptide.micrometer;
+
+import com.google.common.collect.ImmutableList;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import lombok.AllArgsConstructor;
+import org.apiguardian.api.API;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Supplier;
+
+import static com.google.common.collect.ImmutableList.copyOf;
+import static io.micrometer.core.instrument.binder.BaseUnits.TASKS;
+import static io.micrometer.core.instrument.binder.BaseUnits.THREADS;
+import static lombok.AccessLevel.PRIVATE;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+@API(status = EXPERIMENTAL)
+@AllArgsConstructor(access = PRIVATE)
+public final class ThreadPoolMetrics implements MeterBinder {
+
+    private final ThreadPoolExecutor executor;
+    private final String metricName;
+    private final ImmutableList<Tag> defaultTags;
+
+    public ThreadPoolMetrics(final ThreadPoolExecutor executor) {
+        this(executor, "http.client.threads", ImmutableList.of());
+    }
+
+    public ThreadPoolMetrics withMetricName(final String metricName) {
+        return new ThreadPoolMetrics(executor, metricName, defaultTags);
+    }
+
+    public ThreadPoolMetrics withDefaultTags(final Tag... defaultTags) {
+        return withDefaultTags(copyOf(defaultTags));
+    }
+
+    public ThreadPoolMetrics withDefaultTags(final Iterable<Tag> defaultTags) {
+        return new ThreadPoolMetrics(executor, metricName, copyOf(defaultTags));
+    }
+
+    @Override
+    public void bindTo(final MeterRegistry registry) {
+        gauge("available", () -> executor.getPoolSize() - executor.getActiveCount())
+                .description("The number idle threads")
+                .baseUnit(THREADS)
+                .register(registry);
+
+        gauge("leased", executor::getActiveCount)
+                .description("The number of threads that are actively executing tasks")
+                .baseUnit(THREADS)
+                .register(registry);
+
+        gauge("total", executor::getPoolSize)
+                .description("The number of threads that are currently in the pool")
+                .baseUnit(THREADS)
+                .register(registry);
+
+        gauge("min", executor::getCorePoolSize)
+                .description("The minimum number of threads in the pool")
+                .baseUnit(THREADS)
+                .register(registry);
+
+        gauge("max", executor::getMaximumPoolSize)
+                .description("The maximum number of threads in the pool")
+                .baseUnit(THREADS)
+                .register(registry);
+
+        gauge("queued", () -> executor.getQueue().size())
+                .description("The number of queued tasks")
+                .baseUnit(TASKS)
+                .register(registry);
+    }
+
+    private Gauge.Builder<Supplier<Number>> gauge(
+            final String name,
+            final Supplier<Number> supplier) {
+        return Gauge.builder(metricName + "." + name, supplier)
+                .tags(defaultTags);
+    }
+
+}

--- a/riptide-micrometer/src/test/java/org/zalando/riptide/micrometer/ThreadPoolMetricsTest.java
+++ b/riptide-micrometer/src/test/java/org/zalando/riptide/micrometer/ThreadPoolMetricsTest.java
@@ -1,0 +1,75 @@
+package org.zalando.riptide.micrometer;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.zalando.fauxpas.FauxPas.throwingRunnable;
+
+final class ThreadPoolMetricsTest {
+
+    private final ThreadPoolExecutor executor =
+            new ThreadPoolExecutor(1, 3, 1, MINUTES, new LinkedBlockingQueue<>(1));
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @BeforeEach
+    void setUp() {
+        new ThreadPoolMetrics(executor)
+                .withMetricName("http.client.threads")
+                .withDefaultTags(Tag.of("application", "test"))
+                .bindTo(registry);
+    }
+
+    @Test
+    void shouldMeasureInitial() {
+        assertThat(gauge("http.client.threads.available").value(), is(0.0));
+        assertThat(gauge("http.client.threads.leased").value(), is(0.0));
+        assertThat(gauge("http.client.threads.total").value(), is(0.0));
+        assertThat(gauge("http.client.threads.min").value(), is(1.0));
+        assertThat(gauge("http.client.threads.max").value(), is(3.0));
+        assertThat(gauge("http.client.threads.queued").value(), is(0.0));
+    }
+
+    @Test
+    void shouldMeasureIdle() throws InterruptedException {
+        executor.execute(() -> {});
+
+        Thread.sleep(1000);
+
+        assertThat(gauge("http.client.threads.available").value(), is(1.0));
+        assertThat(gauge("http.client.threads.leased").value(), is(0.0));
+        assertThat(gauge("http.client.threads.total").value(), is(1.0));
+        assertThat(gauge("http.client.threads.min").value(), is(1.0));
+        assertThat(gauge("http.client.threads.max").value(), is(3.0));
+        assertThat(gauge("http.client.threads.queued").value(), is(0.0));
+    }
+
+    @Test
+    void shouldMeasureFull() {
+        executor.execute(throwingRunnable(() -> Thread.sleep(1000)));
+        executor.execute(throwingRunnable(() -> Thread.sleep(1000)));
+        executor.execute(throwingRunnable(() -> Thread.sleep(1000)));
+        executor.execute(throwingRunnable(() -> Thread.sleep(1000)));
+
+        assertThat(gauge("http.client.threads.available").value(), is(0.0));
+        assertThat(gauge("http.client.threads.leased").value(), is(3.0));
+        assertThat(gauge("http.client.threads.total").value(), is(3.0));
+        assertThat(gauge("http.client.threads.min").value(), is(1.0));
+        assertThat(gauge("http.client.threads.max").value(), is(3.0));
+        assertThat(gauge("http.client.threads.queued").value(), is(1.0));
+    }
+
+    private Gauge gauge(final String name) {
+        return registry.find(name).tag("application", "test").gauge();
+    }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import io.opentracing.contrib.concurrent.TracedExecutorService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,6 +54,7 @@ import org.zalando.riptide.httpclient.ApacheClientHttpRequestFactory;
 import org.zalando.riptide.httpclient.metrics.HttpConnectionPoolMetrics;
 import org.zalando.riptide.logbook.LogbookPlugin;
 import org.zalando.riptide.micrometer.MicrometerPlugin;
+import org.zalando.riptide.micrometer.ThreadPoolMetrics;
 import org.zalando.riptide.opentracing.OpenTracingPlugin;
 import org.zalando.riptide.opentracing.TracedTaskDecorator;
 import org.zalando.riptide.opentracing.span.SpanDecorator;
@@ -163,10 +163,10 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
         });
 
         if (client.getMetrics().getEnabled()) {
-            registry.registerIfAbsent(id, ExecutorServiceMetrics.class, () ->
-                    genericBeanDefinition(ExecutorServiceMetrics.class)
+            registry.registerIfAbsent(id, ThreadPoolMetrics.class, () ->
+                    genericBeanDefinition(ThreadPoolMetrics.class)
                             .addConstructorArgReference(executorId)
-                            .addConstructorArgValue(name)
+                            .addConstructorArgValue("http.client.threads")
                             .addConstructorArgValue(ImmutableList.of(clientId(id))));
         }
 

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/NetworkMetricsTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/NetworkMetricsTest.java
@@ -35,8 +35,10 @@ final class NetworkMetricsTest {
 
         assertThat(gauge("http.client.connections.available").value(), is(1.0));
         assertThat(gauge("http.client.connections.leased").value(), is(1.0));
+        assertThat(gauge("http.client.connections.total").value(), is(2.0));
+        assertThat(gauge("http.client.connections.min").value(), is(0.0));
         assertThat(gauge("http.client.connections.max").value(), is(20.0));
-        assertThat(gauge("http.client.connections.pending").value(), is(0.0));
+        assertThat(gauge("http.client.connections.queued").value(), is(0.0));
     }
 
     private Gauge gauge(final String name) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- pools now have consistently named metrics:
   - `available`, threads/connections currently free
   - `leased`, threads/connections currently in use
   - `total` = `available`+ `leased`
   - `min`, minimum size (lower bound for `total`)
   - `max`, maximum size (upper bound for `total`)
   - `queued`, tasks/requests currently waiting for a free thread/connection

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
