### PR TITLE
SOAP messages should not be serialized as JSON

### DIFF
--- a/riptide-soap/README.md
+++ b/riptide-soap/README.md
@@ -80,6 +80,14 @@ http.post()
         }))
 ```
 
+In case the response is not interesting it can be discarded:
+
+```java
+http.post()
+    .body(new PlaceOrderRequest(order))
+    .call(soap(pass()));
+```
+
 ## Getting Help
 
 If you have questions, concerns, bug reports, etc., please file an issue in this repository's [Issue Tracker](../../../../issues).

--- a/riptide-soap/src/main/java/org/zalando/riptide/soap/SOAPRoute.java
+++ b/riptide-soap/src/main/java/org/zalando/riptide/soap/SOAPRoute.java
@@ -10,6 +10,7 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.OK;
 import static org.zalando.riptide.Bindings.on;
 import static org.zalando.riptide.Navigators.status;
+import static org.zalando.riptide.Route.call;
 import static org.zalando.riptide.RoutingTree.dispatch;
 
 public final class SOAPRoute {
@@ -18,9 +19,15 @@ public final class SOAPRoute {
 
     }
 
-    public static <T> Route soap(final Class<T> type, final ThrowingConsumer<T, ? extends Exception> consumer) {
+    public static <T> Route soap(
+            final Class<T> type,
+            final ThrowingConsumer<T, ? extends Exception> consumer) {
+        return soap(call(type, consumer));
+    }
+
+    public static <T> Route soap(final Route route) {
         return dispatch(status(),
-                on(OK).call(type, consumer),
+                on(OK).call(route),
                 on(INTERNAL_SERVER_ERROR).call(SOAPFault.class, fault -> {
                     throw new SOAPFaultException(fault);
                 }));

--- a/riptide-soap/src/test/java/org/zalando/riptide/soap/SOAPTest.java
+++ b/riptide-soap/src/test/java/org/zalando/riptide/soap/SOAPTest.java
@@ -3,7 +3,6 @@ package org.zalando.riptide.soap;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
@@ -26,6 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.springframework.http.MediaType.APPLICATION_XML;
 import static org.springframework.http.MediaType.TEXT_XML;
 import static org.zalando.riptide.PassRoute.pass;
 import static org.zalando.riptide.soap.SOAPRoute.soap;
@@ -87,7 +87,7 @@ final class SOAPTest {
     @Test
     void shouldFailToWriteIncompatibleMediaType() {
         final CompletableFuture<ClientHttpResponse> future = unit.post()
-                .contentType(MediaType.APPLICATION_XML)
+                .contentType(APPLICATION_XML)
                 .body(new SayHello("Riptide"))
                 .call(soap(SayHelloResponse.class, System.out::println));
 
@@ -98,6 +98,7 @@ final class SOAPTest {
     @Test
     void shouldFailToWriteFault() {
         final CompletableFuture<ClientHttpResponse> future = unit.post()
+                .accept(TEXT_XML)
                 .body(mock(SOAPFault.class))
                 .call(pass());
 

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
@@ -195,20 +195,6 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
 
             final String objectMapperId = findObjectMapper(id);
 
-            log.debug("Client [{}]: Registering MappingJackson2HttpMessageConverter referencing [{}]", id,
-                    objectMapperId);
-            list.add(genericBeanDefinition(MappingJackson2HttpMessageConverter.class)
-                    .addConstructorArgReference(objectMapperId)
-                    .getBeanDefinition());
-
-            ifPresent("org.zalando.riptide.stream.Streams", () -> {
-                log.debug("Client [{}]: Registering StreamConverter referencing [{}]", id, objectMapperId);
-                list.add(genericBeanDefinition(Streams.class)
-                        .setFactoryMethod("streamConverter")
-                        .addConstructorArgReference(objectMapperId)
-                        .getBeanDefinition());
-            });
-
             if (client.getSoap().getEnabled()) {
                 final Map<String, String> protocols = ImmutableMap.of(
                         "1.1", SOAPConstants.SOAP_1_1_PROTOCOL,
@@ -228,6 +214,20 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
                         .addConstructorArgValue(protocol)
                         .getBeanDefinition());
             }
+
+            log.debug("Client [{}]: Registering MappingJackson2HttpMessageConverter referencing [{}]", id,
+                    objectMapperId);
+            list.add(genericBeanDefinition(MappingJackson2HttpMessageConverter.class)
+                    .addConstructorArgReference(objectMapperId)
+                    .getBeanDefinition());
+
+            ifPresent("org.zalando.riptide.stream.Streams", () -> {
+                log.debug("Client [{}]: Registering StreamConverter referencing [{}]", id, objectMapperId);
+                list.add(genericBeanDefinition(Streams.class)
+                        .setFactoryMethod("streamConverter")
+                        .addConstructorArgReference(objectMapperId)
+                        .getBeanDefinition());
+            });
 
             log.debug("Client [{}]: Registering StringHttpMessageConverter", id);
             list.add(genericBeanDefinition(StringHttpMessageConverter.class)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Re-ordered message converters to put SOAP message converters before JSON.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jackson will always be picked first, because it's configured first. Only by explicitly specifying a content type `text/xml` one can force SOAP messages right now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
