### PR TITLE
Connection leak on failure to parse body

### DIFF
--- a/riptide-core/src/main/java/org/zalando/riptide/DefaultMessageReader.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/DefaultMessageReader.java
@@ -51,6 +51,7 @@ final class DefaultMessageReader implements MessageReader {
                 throw e;
             }
         } catch (final RestClientException e) {
+            // unpack wrapped exception (Spring 5 only)
             propagateIfPossible(e.getCause(), IOException.class, HttpMessageNotReadableException.class);
             throw e;
         }

--- a/riptide-core/src/main/java/org/zalando/riptide/DefaultMessageReader.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/DefaultMessageReader.java
@@ -44,9 +44,13 @@ final class DefaultMessageReader implements MessageReader {
     private <I> I readBody(final Type type, final ClientHttpResponse response) throws IOException {
         final ResponseExtractor<I> extractor = new HttpMessageConverterExtractor<>(type, converters);
         try {
-            return extractor.extractData(response);
+            try {
+                return extractor.extractData(response);
+            } catch (final IOException | RuntimeException e) {
+                response.close();
+                throw e;
+            }
         } catch (final RestClientException e) {
-            response.close();
             propagateIfPossible(e.getCause(), IOException.class, HttpMessageNotReadableException.class);
             throw e;
         }

--- a/riptide-core/src/main/java/org/zalando/riptide/DefaultMessageReader.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/DefaultMessageReader.java
@@ -46,6 +46,7 @@ final class DefaultMessageReader implements MessageReader {
         try {
             return extractor.extractData(response);
         } catch (final RestClientException e) {
+            response.close();
             propagateIfPossible(e.getCause(), IOException.class, HttpMessageNotReadableException.class);
             throw e;
         }

--- a/riptide-httpclient/src/test/java/org/zalando/riptide/httpclient/AbstractApacheClientHttpRequestFactoryTest.java
+++ b/riptide-httpclient/src/test/java/org/zalando/riptide/httpclient/AbstractApacheClientHttpRequestFactoryTest.java
@@ -22,6 +22,7 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.zalando.fauxpas.ThrowingRunnable;
 import org.zalando.riptide.Http;
 import org.zalando.riptide.capture.Capture;
 import org.zalando.riptide.httpclient.ApacheClientHttpRequestFactory.Mode;
@@ -191,7 +192,7 @@ public abstract class AbstractApacheClientHttpRequestFactoryTest {
         driver.addExpectation(onRequestTo("/wrong-content-type"), giveResponse("[]", "text/plain"));
         driver.addExpectation(onRequestTo("/wrong-content-type"), giveResponse("[]", "text/plain"));
 
-        final Runnable request = throwingRunnable(() -> {
+        final ThrowingRunnable<Throwable> request = throwingRunnable(() -> {
             try {
                 http.get("/wrong-content-type")
                         .dispatch(series(),


### PR DESCRIPTION
In case the DefaultMessageReader fails to parse the response body, connections are not returned to the connection pool and stay leased forever.

## Description

A test has been added to show the following scenario:

* the `DefaultMessageReader` fails to parse the response body
* a `RestClientException is raised`
* client connection is not returned to the connection pool and stay leased forever
* connection pool gets exhausted

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
