### PR TITLE
Added mock authorization provider for @RiptideClientTests

### DIFF
--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -635,7 +635,7 @@ final class RiptideTest {
 }
 ```
 
-**Beware** that all components of a client below and including `ClientHttpRequestFactory` are replaced by mocks.
+**Beware** that all components of a client below and including `ClientHttpRequestFactory` are replaced by mocks. In addition, if enabled the `AuthorizationProvider` will default to a mock implementation for tests.
 
 ## Getting Help
 

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/MockAuthorizationProvider.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/MockAuthorizationProvider.java
@@ -1,0 +1,12 @@
+package org.zalando.riptide.autoconfigure;
+
+import org.zalando.riptide.auth.AuthorizationProvider;
+
+final class MockAuthorizationProvider implements AuthorizationProvider {
+
+    @Override
+    public String get() {
+        return "Bearer fake-test-token";
+    }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/testing/RiptideClientTestTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/testing/RiptideClientTestTest.java
@@ -1,5 +1,6 @@
 package org.zalando.riptide.autoconfigure.testing;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +9,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.zalando.riptide.autoconfigure.RiptideClientTest;
 
+import static org.hamcrest.Matchers.anything;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
@@ -29,9 +32,21 @@ final class RiptideClientTestTest {
 
     @Test
     void shouldAutowireMockedHttp() {
-        server.expect(requestTo("https://example.com/foo/bar")).andRespond(withSuccess());
+        server.expect(requestTo("https://example.com/foo/bar"))
+                .andRespond(withSuccess());
         client.callViaHttp();
-        server.verify();
     }
 
+    @Test
+    void shouldMockAuthorizationProvider() {
+        server.expect(requestTo("https://example.com/foo/bar"))
+                .andExpect(header("Authorization", anything()))
+                .andRespond(withSuccess());
+        client.callViaHttp();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.verify();
+    }
 }

--- a/riptide-spring-boot-autoconfigure/src/test/resources/application-testing.yml
+++ b/riptide-spring-boot-autoconfigure/src/test/resources/application-testing.yml
@@ -11,6 +11,8 @@ riptide:
         max-size: 100
         keep-alive: 5 minutes
         queue-size: 10
+      oauth:
+        enabled: true
       circuit-breaker:
         enabled: true
         failure-threshold: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As of now, users of `@RiptideClientTest` that had `riptide.clients.example.oauth.enabled: true` would suffer from the following exception during tests:

```
java.nio.file.NoSuchFileException: /meta/credentials/example-token-type
```

Currently there are several workarounds, each with their own drawbacks:

1. `@SpringBootTest(properties="riptide.clients.example.oauth.enabled: false")`
   - needs to be done for each client in each test
2. Register a custom `AuthorizationProvider`
   - needs to implemented (`return () -> "fake";`)
   - needs to be done for each client in each test
3. Change credentials directory and either mount secrets or have static files prepared
   - needs to keep track of file resources
   - needs to be done for each client
 
This pull request still allows to use any of those, but when using `@RiptideClientTest` it will register a mock `AuthorizationProvider` by default that will return a static string. That way, if needed, it can still be overridden, but users will get a less annoying default behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
