### PR TITLE
Update documentation on queue configuration

### DIFF
--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -394,7 +394,7 @@ For a complete overview of available properties, they type and default value ple
 | `│   │   ├── min-size`                  | `int`          | `1`                                              |
 | `│   │   ├── max-size`                  | `int`          | same as `connections.max-total`                  |
 | `│   │   ├── keep-alive`                | `TimeSpan`     | `1 minute`                                       |
-| `│   │   └── queue-size`                | `int`          | `0` (unbounded)                                  |
+| `│   │   └── queue-size`                | `int`          | `0` (no queue)                                   |
 | `│   ├── timeouts`                      |                |                                                  |
 | `│   │   ├── enabled`                   | `boolean`      | `false`                                          |
 | `│   │   └── global`                    | `TimeSpan`     | none                                             |


### PR DESCRIPTION
* default value of 0 configures a SynchronousQueue
* ThreadPoolExecutor will always reject with such queue
* users may configure "unbounded" queue by specifying Int.MAX
* adapting documentation to keep behavior

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
