### PR TITLE
Avoid threads being scheduled twice

### DIFF
--- a/riptide-core/src/main/java/org/zalando/riptide/AsyncPlugin.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/AsyncPlugin.java
@@ -20,12 +20,4 @@ final class AsyncPlugin implements Plugin {
                 .thenCompose(identity());
     }
 
-    @Override
-    public RequestExecution aroundNetwork(final RequestExecution execution) {
-        return arguments ->
-                execution.execute(arguments)
-                        .whenCompleteAsync((r, e) -> {
-                            // this will force any further callbacks to be executed using the executor
-                        }, executor);
-    }
 }


### PR DESCRIPTION
## Description

Currently threads are being scheduled twice on their request executor.

* at the very start of a Riptide request (required for isolation)
* after the network phase (intented to force execution back on request
executor)

The second handover was introduced with NIO to accomodate for request
factories which use their own pool. The benefit of forcing execution
back on the request executor is questionable, as any IO is done by
definition after the network phase.

Removing the handover prevents the same excution being scheduled twice
onto the same request executor. In high pressure situations (more
requests than configured threads on a single client), this leads to
deadlock situations in which running executions cannot leave the network
phase, as all other threads are occupied with new executions waiting for
a free slot to start.

## Motivation and Context

We are running in such deadlocks.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
