### PR TITLE
Added alternative thread pool semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,42 @@ This defaults to:
 - same list of converters as `new RestTemplate()`
 - [`OriginalStackTracePlugin`](#plugins)
 
+### Thread Pool
+
+Instead of using `Executors.newCachedThreadPool()` Riptide offers an alternative builder to create a custom `ThreadPoolExecutor`.
+
+You have to pick one of two different flavors of thread pools:
+
+1. Queue-first
+
+    This is the default behavior for Java thread pools where the pool scales up to the core pool size, then fills the queue and then starts to grow until it reaches the maximum pool size:
+    
+    ```java
+    ThreadPoolExecutors.builder()
+        .corePoolSize(5)
+        .maximumPoolSize(20)
+        .keepAlive(1, MINUTES)
+        .build()
+    ```
+
+2. Scale-first
+
+    An alternative approach is to scale first up to the maximum pool size and then fill the queue:
+    
+    ```java
+    ThreadPoolExecutors.builder()
+        .workQueue(20)
+        .maximumPoolSize(20)
+        .keepAlive(1, MINUTES)
+        .build()
+    ```
+
+⚠️ Work queue and core pool size are mutually exclusive in this approach.
+
+You can read more about those two approaches here:
+- [Java Scale First ExecutorService — A myth or a reality](https://medium.com/@uditharosha/java-scale-first-executorservice-4245a63222df)
+- [How to get the ThreadPoolExecutor to increase threads to max before queueing?](https://stackoverflow.com/questions/19528304/how-to-get-the-threadpoolexecutor-to-increase-threads-to-max-before-queueing)
+
 In order to configure the thread pool correctly, please refer to
 [How to set an ideal thread pool size](https://jobs.zalando.com/tech/blog/how-to-set-an-ideal-thread-pool-size).
 
@@ -182,7 +218,7 @@ Non-blocking IO is asynchronous by nature. In order to provide asynchrony for bl
 |                 | Synchronous                                  | Asynchronous                                      |
 |-----------------|----------------------------------------------|---------------------------------------------------|
 | Blocking IO     | `Runnable::run` + `ClientHttpRequestFactory` | `Executor` + `ClientHttpRequestFactory`           |
-| Non-blocking IO | n/a                                          | `Runnable::run` + `AsyncClientHttpRequestFactory` |
+| Non-blocking IO | n/a                                          | `AsyncClientHttpRequestFactory` |
 
 ## Usage
 

--- a/riptide-core/src/main/java/org/zalando/riptide/ThreadPoolExecutorBuilder.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/ThreadPoolExecutorBuilder.java
@@ -1,0 +1,105 @@
+package org.zalando.riptide;
+
+import lombok.AllArgsConstructor;
+import lombok.With;
+import org.zalando.riptide.ThreadPoolExecutors.Builder;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.Executors.defaultThreadFactory;
+import static lombok.AccessLevel.PRIVATE;
+import static org.zalando.riptide.ThreadPoolExecutors.Build;
+import static org.zalando.riptide.ThreadPoolExecutors.CorePoolSize;
+import static org.zalando.riptide.ThreadPoolExecutors.KeepAliveTime;
+import static org.zalando.riptide.ThreadPoolExecutors.MaximumPoolSize;
+import static org.zalando.riptide.ThreadPoolExecutors.RejectedExecutions;
+import static org.zalando.riptide.ThreadPoolExecutors.Threads;
+import static org.zalando.riptide.ThreadPoolExecutors.WorkQueue;
+
+@With(PRIVATE)
+@AllArgsConstructor
+final class ThreadPoolExecutorBuilder implements
+        Builder, WorkQueue, CorePoolSize, MaximumPoolSize, KeepAliveTime,
+        Threads, RejectedExecutions, Build {
+
+    private final Integer queueSize;
+    private final Integer corePoolSize;
+    private final Integer maximumPoolSize;
+    private final Long keepAliveTime;
+    private final TimeUnit unit;
+    private final ThreadFactory threadFactory;
+    private final RejectedExecutionHandler handler;
+
+    public ThreadPoolExecutorBuilder() {
+        this(0, 0, null, null, null,
+                defaultThreadFactory(), new AbortPolicy());
+    }
+
+    @Override
+    public MaximumPoolSize workQueue(final int queueSize) {
+        return withQueueSize(queueSize);
+    }
+
+    @Override
+    public MaximumPoolSize corePoolSize(final int corePoolSize) {
+        return withCorePoolSize(corePoolSize);
+    }
+
+    @Override
+    public KeepAliveTime maximumPoolSize(final int maximumPoolSize) {
+        return withMaximumPoolSize(maximumPoolSize);
+    }
+
+    @Override
+    public Threads keepAlive(final long time, final TimeUnit unit) {
+        return withKeepAliveTime(time).withUnit(unit);
+    }
+
+    @Override
+    public RejectedExecutions threadFactory(final ThreadFactory threadFactory) {
+        return withThreadFactory(threadFactory);
+    }
+
+    @Override
+    public Build handler(final RejectedExecutionHandler handler) {
+        return withHandler(handler);
+    }
+
+    @Override
+    public ThreadPoolExecutor build() {
+        if (queueSize == 0) {
+            return new ThreadPoolExecutor(
+                    corePoolSize,
+                    maximumPoolSize,
+                    keepAliveTime,
+                    unit,
+                    new SynchronousQueue<>(),
+                    threadFactory,
+                    handler
+            );
+        } else {
+            final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                    maximumPoolSize,
+                    maximumPoolSize,
+                    keepAliveTime,
+                    unit,
+                    new ArrayBlockingQueue<>(queueSize),
+                    threadFactory,
+                    handler
+            );
+
+            if (keepAliveTime > 0) {
+                executor.allowCoreThreadTimeOut(true);
+            }
+
+            return executor;
+        }
+    }
+
+}

--- a/riptide-core/src/main/java/org/zalando/riptide/ThreadPoolExecutors.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/ThreadPoolExecutors.java
@@ -1,0 +1,55 @@
+package org.zalando.riptide;
+
+import org.apiguardian.api.API;
+
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+@API(status = EXPERIMENTAL)
+public final class ThreadPoolExecutors {
+
+    public interface Builder extends CorePoolSize, WorkQueue {
+
+    }
+
+    public interface WorkQueue {
+        MaximumPoolSize workQueue(int queueSize);
+    }
+
+    public interface CorePoolSize {
+        MaximumPoolSize corePoolSize(int corePoolSize);
+    }
+
+    public interface MaximumPoolSize {
+        KeepAliveTime maximumPoolSize(int maxSize);
+    }
+
+    public interface KeepAliveTime {
+        Threads keepAlive(long time, TimeUnit unit);
+    }
+
+    public interface Threads extends Build {
+        RejectedExecutions threadFactory(ThreadFactory threadFactory);
+    }
+
+    public interface RejectedExecutions extends Build {
+        Build handler(RejectedExecutionHandler handler);
+    }
+
+    public interface Build {
+        ThreadPoolExecutor build();
+    }
+
+    private ThreadPoolExecutors() {
+
+    }
+
+    public static Builder builder() {
+        return new ThreadPoolExecutorBuilder();
+    }
+
+}

--- a/riptide-core/src/test/java/org/zalando/riptide/ThreadPoolExecutorsTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/ThreadPoolExecutorsTest.java
@@ -1,0 +1,98 @@
+package org.zalando.riptide;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.zalando.fauxpas.FauxPas.throwingRunnable;
+
+final class ThreadPoolExecutorsTest {
+
+    @Test
+    void allowsNoQueue() {
+        verifyNoQueue(ThreadPoolExecutors.builder()
+                .corePoolSize(0)
+                .maximumPoolSize(1)
+                .keepAlive(0, TimeUnit.MINUTES)
+                .threadFactory(Executors.defaultThreadFactory())
+                .handler(new AbortPolicy())
+                .build());
+    }
+
+    @Test
+    void allowsQueueSizeZero() {
+        verifyNoQueue(ThreadPoolExecutors.builder()
+                .workQueue(0)
+                .maximumPoolSize(1)
+                .keepAlive(0, TimeUnit.MINUTES)
+                .threadFactory(Executors.defaultThreadFactory())
+                .handler(new AbortPolicy())
+                .build());
+    }
+
+    private void verifyNoQueue(final ThreadPoolExecutor executor) {
+        try {
+            final CountDownLatch latch = new CountDownLatch(1);
+
+            executor.execute(throwingRunnable(latch::await));
+            assertThrows(RejectedExecutionException.class, () ->
+                    executor.execute(() -> {}));
+
+            latch.countDown();
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    void scalesFirst() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .workQueue(1)
+                .maximumPoolSize(2)
+                .keepAlive(1, TimeUnit.MINUTES)
+                .build();
+
+        verifyQueue(executor);
+    }
+
+    @Test
+    void supportsKeepAliveTimeOfZero() {
+        verifyQueue(ThreadPoolExecutors.builder()
+                .workQueue(1)
+                .maximumPoolSize(2)
+                .keepAlive(0, TimeUnit.MINUTES)
+                .build());
+    }
+
+    private void verifyQueue(final ThreadPoolExecutor executor) {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        try {
+            assertEquals(0, executor.getPoolSize());
+            assertEquals(0, executor.getQueue().size());
+
+            executor.execute(throwingRunnable(latch::await));
+            executor.execute(throwingRunnable(latch::await));
+
+            assertEquals(2, executor.getPoolSize());
+            assertEquals(0, executor.getQueue().size());
+
+            executor.execute(throwingRunnable(latch::await));
+
+            assertEquals(2, executor.getPoolSize());
+            assertEquals(1, executor.getQueue().size());
+
+            latch.countDown();
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/ThreadPoolFactory.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/ThreadPoolFactory.java
@@ -1,0 +1,37 @@
+package org.zalando.riptide.autoconfigure;
+
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+import org.zalando.riptide.ThreadPoolExecutors.MaximumPoolSize;
+import org.zalando.riptide.autoconfigure.RiptideProperties.Threads;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.zalando.riptide.ThreadPoolExecutors.builder;
+
+@SuppressWarnings("unused")
+final class ThreadPoolFactory {
+
+    private ThreadPoolFactory() {
+
+    }
+
+    public static ThreadPoolExecutor create(
+            final String id,
+            final Threads threads) {
+
+        final TimeSpan keepAlive = threads.getKeepAlive();
+        return configure(threads)
+                .maximumPoolSize(threads.getMaxSize())
+                .keepAlive(keepAlive.getAmount(), keepAlive.getUnit())
+                .threadFactory(new CustomizableThreadFactory("http-" + id + "-"))
+                .build();
+    }
+
+    private static MaximumPoolSize configure(final Threads threads) {
+        final int queueSize = threads.getQueueSize();
+        return queueSize == 0 ?
+                builder().corePoolSize(threads.getMinSize()) :
+                builder().workQueue(queueSize);
+    }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/ManualConfiguration.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/ManualConfiguration.java
@@ -32,6 +32,7 @@ import org.zalando.logbook.autoconfigure.LogbookAutoConfiguration;
 import org.zalando.riptide.Http;
 import org.zalando.riptide.OriginalStackTracePlugin;
 import org.zalando.riptide.Plugin;
+import org.zalando.riptide.ThreadPoolExecutors;
 import org.zalando.riptide.UrlResolution;
 import org.zalando.riptide.auth.AuthorizationPlugin;
 import org.zalando.riptide.auth.PlatformCredentialsAuthorizationProvider;
@@ -71,11 +72,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.function.Predicate;
 
 import static java.time.Clock.systemUTC;
@@ -226,11 +224,12 @@ public class ManualConfiguration {
         @Bean(destroyMethod = "shutdown")
         public ExecutorService executor(final Tracer tracer) {
             return new TracedExecutorService(
-                    new ThreadPoolExecutor(
-                            1, 20, 1, MINUTES,
-                            new ArrayBlockingQueue<>(0),
-                            new CustomizableThreadFactory("http-example-"),
-                            new AbortPolicy()),
+                    ThreadPoolExecutors.builder()
+                        .corePoolSize(1)
+                        .maximumPoolSize(20)
+                        .keepAlive(1, MINUTES)
+                        .threadFactory(new CustomizableThreadFactory("http-example-"))
+                        .build(),
                     tracer);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Instead of queuing first, thread pools that use a queue will be scaling first up to maximum pool size before they start queuing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
