### PR TITLE
Added alternative thread pool semantics

### DIFF
--- a/riptide-core/src/main/java/org/zalando/riptide/concurrent/ThreadPoolExecutorBuilder.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/concurrent/ThreadPoolExecutorBuilder.java
@@ -1,0 +1,122 @@
+package org.zalando.riptide.concurrent;
+
+import lombok.AllArgsConstructor;
+import lombok.With;
+import org.zalando.riptide.concurrent.ThreadPoolExecutors.Builder;
+import org.zalando.riptide.concurrent.ThreadPoolExecutors.FixedOrElasticSize;
+import org.zalando.riptide.concurrent.ThreadPoolExecutors.FixedSize;
+import org.zalando.riptide.concurrent.ThreadPoolExecutors.LimitedElasticSize;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.Executors.defaultThreadFactory;
+import static lombok.AccessLevel.PRIVATE;
+import static org.zalando.riptide.concurrent.ThreadPoolExecutors.Build;
+import static org.zalando.riptide.concurrent.ThreadPoolExecutors.ElasticSize;
+import static org.zalando.riptide.concurrent.ThreadPoolExecutors.KeepAliveTime;
+import static org.zalando.riptide.concurrent.ThreadPoolExecutors.RejectedExecutions;
+import static org.zalando.riptide.concurrent.ThreadPoolExecutors.ScaleFirst;
+import static org.zalando.riptide.concurrent.ThreadPoolExecutors.Threads;
+
+@With(PRIVATE)
+@AllArgsConstructor
+final class ThreadPoolExecutorBuilder implements
+        Builder, ScaleFirst,
+        FixedSize, ElasticSize, LimitedElasticSize, FixedOrElasticSize,
+        KeepAliveTime, Threads, RejectedExecutions, Build {
+
+    private final Integer corePoolSize;
+    private final Integer maximumPoolSize;
+    private final Long keepAliveTime;
+    private final TimeUnit unit;
+    private final boolean allowCoreThreadTimeOut;
+    private final BlockingQueue<Runnable> queue;
+    private final ThreadFactory threadFactory;
+    private final RejectedExecutionHandler handler;
+
+    public ThreadPoolExecutorBuilder() {
+        this(null, null, null, null, false, null,
+                defaultThreadFactory(), new AbortPolicy());
+    }
+
+    @Override
+    public ScaleFirst scaleFirst() {
+        return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder boundedQueue(final int queueSize) {
+        return queueSize == 0 ?
+                withQueue(new SynchronousQueue<>()) :
+                withQueue(new ArrayBlockingQueue<>(queueSize));
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder unboundedQueue() {
+        return withQueue(new LinkedBlockingQueue<>());
+    }
+
+    @Override
+    public KeepAliveTime fixedSize(final int poolSize) {
+        return withCorePoolSize(poolSize)
+                .withMaximumPoolSize(poolSize);
+    }
+
+    @Override
+    public KeepAliveTime elasticSize(
+            final int corePoolSize, final int maximumPoolSize) {
+
+        return withCorePoolSize(corePoolSize)
+                .withMaximumPoolSize(maximumPoolSize);
+    }
+
+    @Override
+    public KeepAliveTime elasticSize(final int maximumPoolSize) {
+        return withCorePoolSize(maximumPoolSize)
+                .withMaximumPoolSize(maximumPoolSize)
+                .withAllowCoreThreadTimeOut(true);
+    }
+
+    @Override
+    public Threads keepAlive(final long time, final TimeUnit unit) {
+        return withKeepAliveTime(time).withUnit(unit);
+    }
+
+    @Override
+    public RejectedExecutions threadFactory(final ThreadFactory threadFactory) {
+        return withThreadFactory(threadFactory);
+    }
+
+    @Override
+    public Build handler(final RejectedExecutionHandler handler) {
+        return withHandler(handler);
+    }
+
+    @Override
+    public ThreadPoolExecutor build() {
+        final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                corePoolSize,
+                maximumPoolSize,
+                keepAliveTime,
+                unit,
+                queue,
+                threadFactory,
+                handler
+        );
+
+        if (keepAliveTime > 0) {
+            executor.allowCoreThreadTimeOut(allowCoreThreadTimeOut);
+        }
+
+        return executor;
+    }
+
+}

--- a/riptide-core/src/main/java/org/zalando/riptide/concurrent/ThreadPoolExecutors.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/concurrent/ThreadPoolExecutors.java
@@ -1,0 +1,89 @@
+package org.zalando.riptide.concurrent;
+
+import org.apiguardian.api.API;
+
+import javax.annotation.CheckReturnValue;
+import java.time.Duration;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+@API(status = EXPERIMENTAL)
+public final class ThreadPoolExecutors {
+
+    @CheckReturnValue
+    public interface Builder {
+
+        default FixedOrElasticSize withoutQueue() {
+            return boundedQueue(0);
+        }
+
+        FixedOrElasticSize boundedQueue(int queueSize);
+        FixedSize unboundedQueue();
+        ScaleFirst scaleFirst();
+
+    }
+
+    @CheckReturnValue
+    public interface ScaleFirst {
+        LimitedElasticSize boundedQueue(int queueSize);
+        LimitedElasticSize unboundedQueue();
+    }
+
+    public interface FixedOrElasticSize extends FixedSize, ElasticSize {
+
+    }
+
+    @CheckReturnValue
+    public interface FixedSize {
+        KeepAliveTime fixedSize(int poolSize);
+    }
+
+    @CheckReturnValue
+    public interface ElasticSize {
+        KeepAliveTime elasticSize(int corePoolSize, int maximumPoolSize);
+    }
+
+    @CheckReturnValue
+    public interface LimitedElasticSize {
+        KeepAliveTime elasticSize(int maximumPoolSize);
+    }
+
+    @CheckReturnValue
+    public interface KeepAliveTime {
+
+        default Threads keepAlive(final Duration duration) {
+            return keepAlive(duration.toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        Threads keepAlive(long time, TimeUnit unit);
+
+    }
+
+    @CheckReturnValue
+    public interface Threads extends Build {
+        RejectedExecutions threadFactory(ThreadFactory threadFactory);
+    }
+
+    @CheckReturnValue
+    public interface RejectedExecutions extends Build {
+        Build handler(RejectedExecutionHandler handler);
+    }
+
+    @CheckReturnValue
+    public interface Build {
+        ThreadPoolExecutor build();
+    }
+
+    private ThreadPoolExecutors() {
+
+    }
+
+    public static Builder builder() {
+        return new ThreadPoolExecutorBuilder();
+    }
+
+}

--- a/riptide-core/src/main/java/org/zalando/riptide/concurrent/package-info.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/concurrent/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package org.zalando.riptide.concurrent;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/riptide-core/src/test/java/org/zalando/riptide/concurrent/ThreadPoolExecutorsTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/concurrent/ThreadPoolExecutorsTest.java
@@ -1,0 +1,150 @@
+package org.zalando.riptide.concurrent;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+final class ThreadPoolExecutorsTest {
+
+    @Test
+    void withoutQueueFixedSize() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .withoutQueue()
+                .fixedSize(1)
+                .keepAlive(Duration.ofMinutes(1))
+                .build();
+
+        assertThat(executor.getCorePoolSize(), is(1));
+        assertThat(executor.getMaximumPoolSize(), is(1));
+        assertThat(executor.getQueue(), is(instanceOf(SynchronousQueue.class)));
+        assertThat(executor.allowsCoreThreadTimeOut(), is(false));
+    }
+
+    @Test
+    void withoutQueueElasticSize() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .withoutQueue()
+                .elasticSize(0, 1)
+                .keepAlive(Duration.ofMinutes(1))
+                .build();
+
+        assertThat(executor.getCorePoolSize(), is(0));
+        assertThat(executor.getMaximumPoolSize(), is(1));
+        assertThat(executor.getQueue(), is(instanceOf(SynchronousQueue.class)));
+        assertThat(executor.allowsCoreThreadTimeOut(), is(false));
+    }
+
+    @Test
+    void emptyBoundedQueueEqualsNoQueue() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .boundedQueue(0)
+                .fixedSize(1)
+                .keepAlive(Duration.ofMinutes(1))
+                .build();
+
+        assertThat(executor.getCorePoolSize(), is(1));
+        assertThat(executor.getMaximumPoolSize(), is(1));
+        assertThat(executor.getQueue(), is(instanceOf(SynchronousQueue.class)));
+        assertThat(executor.allowsCoreThreadTimeOut(), is(false));
+    }
+
+    @Test
+    void boundedQueueFixedSize() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .boundedQueue(1)
+                .fixedSize(1)
+                .keepAlive(Duration.ofMinutes(1))
+                .build();
+
+        assertThat(executor.getCorePoolSize(), is(1));
+        assertThat(executor.getMaximumPoolSize(), is(1));
+        assertThat(executor.getQueue(), is(instanceOf(ArrayBlockingQueue.class)));
+        assertThat(executor.allowsCoreThreadTimeOut(), is(false));
+    }
+
+    @Test
+    void boundedQueueElasticSize() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .boundedQueue(1)
+                .elasticSize(0, 1)
+                .keepAlive(Duration.ofMinutes(1))
+                .threadFactory(Executors.defaultThreadFactory())
+                .handler(new CallerRunsPolicy())
+                .build();
+
+        assertThat(executor.getCorePoolSize(), is(0));
+        assertThat(executor.getMaximumPoolSize(), is(1));
+        assertThat(executor.getQueue(), is(instanceOf(ArrayBlockingQueue.class)));
+        assertThat(executor.allowsCoreThreadTimeOut(), is(false));
+    }
+
+    @Test
+    void unboundedQueueFixedSize() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .unboundedQueue()
+                .fixedSize(1)
+                .keepAlive(Duration.ofMinutes(1))
+                .build();
+
+        assertThat(executor.getCorePoolSize(), is(1));
+        assertThat(executor.getMaximumPoolSize(), is(1));
+        assertThat(executor.getQueue(), is(instanceOf(LinkedBlockingQueue.class)));
+        assertThat(executor.allowsCoreThreadTimeOut(), is(false));
+    }
+
+    @Test
+    void scaleFirstBoundedQueueElasticSize() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .scaleFirst()
+                .boundedQueue(1)
+                .elasticSize(1)
+                .keepAlive(Duration.ofMinutes(1))
+                .build();
+
+        assertThat(executor.getCorePoolSize(), is(1));
+        assertThat(executor.getMaximumPoolSize(), is(1));
+        assertThat(executor.getQueue(), is(instanceOf(ArrayBlockingQueue.class)));
+        assertThat(executor.allowsCoreThreadTimeOut(), is(true));
+    }
+
+    @Test
+    void scaleFirstUnboundedQueueElasticSize() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .scaleFirst()
+                .unboundedQueue()
+                .elasticSize(1)
+                .keepAlive(Duration.ofMinutes(1))
+                .build();
+
+        assertThat(executor.getCorePoolSize(), is(1));
+        assertThat(executor.getMaximumPoolSize(), is(1));
+        assertThat(executor.getQueue(), is(instanceOf(LinkedBlockingQueue.class)));
+        assertThat(executor.allowsCoreThreadTimeOut(), is(true));
+    }
+
+    @Test
+    void scaleFirstUnboundedQueueElasticSizeWithoutKeepAlive() {
+        final ThreadPoolExecutor executor = ThreadPoolExecutors.builder()
+                .scaleFirst()
+                .unboundedQueue()
+                .elasticSize(1)
+                .keepAlive(Duration.ZERO)
+                .build();
+
+        assertThat(executor.getCorePoolSize(), is(1));
+        assertThat(executor.getMaximumPoolSize(), is(1));
+        assertThat(executor.getQueue(), is(instanceOf(LinkedBlockingQueue.class)));
+        assertThat(executor.allowsCoreThreadTimeOut(), is(false));
+    }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/ThreadPoolFactory.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/ThreadPoolFactory.java
@@ -1,0 +1,50 @@
+package org.zalando.riptide.autoconfigure;
+
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+import org.zalando.riptide.autoconfigure.RiptideProperties.Threads;
+import org.zalando.riptide.concurrent.ThreadPoolExecutors.KeepAliveTime;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.zalando.riptide.concurrent.ThreadPoolExecutors.builder;
+
+@SuppressWarnings("unused")
+final class ThreadPoolFactory {
+
+    private ThreadPoolFactory() {
+
+    }
+
+    public static ThreadPoolExecutor create(
+            final String id,
+            final Threads threads) {
+
+        final TimeSpan keepAlive = threads.getKeepAlive();
+        return configure(threads)
+                .keepAlive(keepAlive.getAmount(), keepAlive.getUnit())
+                .threadFactory(new CustomizableThreadFactory("http-" + id + "-"))
+                .build();
+    }
+
+    private static KeepAliveTime configure(final Threads threads) {
+        final int minSize = threads.getMinSize();
+        final int maxSize = threads.getMaxSize();
+        final int queueSize = threads.getQueueSize();
+
+        if (queueSize == 0) {
+            return builder()
+                    .withoutQueue()
+                    .elasticSize(minSize, maxSize);
+        } else if (minSize == maxSize) {
+            return builder()
+                    .boundedQueue(queueSize)
+                    .fixedSize(maxSize);
+        } else {
+            return builder()
+                    .scaleFirst()
+                    .boundedQueue(queueSize)
+                    .elasticSize(maxSize);
+        }
+    }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/ManualConfiguration.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/ManualConfiguration.java
@@ -44,6 +44,7 @@ import org.zalando.riptide.chaos.Probability;
 import org.zalando.riptide.compatibility.AsyncHttpOperations;
 import org.zalando.riptide.compatibility.HttpOperations;
 import org.zalando.riptide.compression.RequestCompressionPlugin;
+import org.zalando.riptide.concurrent.ThreadPoolExecutors;
 import org.zalando.riptide.failsafe.BackupRequest;
 import org.zalando.riptide.failsafe.CircuitBreakerListener;
 import org.zalando.riptide.failsafe.CompositeDelayFunction;
@@ -71,11 +72,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.function.Predicate;
 
 import static java.time.Clock.systemUTC;
@@ -226,11 +224,12 @@ public class ManualConfiguration {
         @Bean(destroyMethod = "shutdown")
         public ExecutorService executor(final Tracer tracer) {
             return new TracedExecutorService(
-                    new ThreadPoolExecutor(
-                            1, 20, 1, MINUTES,
-                            new ArrayBlockingQueue<>(0),
-                            new CustomizableThreadFactory("http-example-"),
-                            new AbortPolicy()),
+                    ThreadPoolExecutors.builder()
+                        .withoutQueue()
+                        .elasticSize(1, 20)
+                        .keepAlive(1, MINUTES)
+                        .threadFactory(new CustomizableThreadFactory("http-example-"))
+                        .build(),
                     tracer);
         }
 

--- a/riptide-spring-boot-autoconfigure/src/test/resources/application-testing.yml
+++ b/riptide-spring-boot-autoconfigure/src/test/resources/application-testing.yml
@@ -7,8 +7,8 @@ riptide:
         connection-timout: 2000 milliseconds
         socket-timeout: 3000 milliseconds
       threads:
-        min-size: 0
-        max-size: 100
+        min-size: 10
+        max-size: 10
         keep-alive: 5 minutes
         queue-size: 10
       oauth:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Instead of queuing first, thread pools that use a queue will be scaling first up to maximum pool size before they start queuing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
