### PR TITLE
Made thread pool optional and configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The following implementations offer non-blocking IO:
 - [`Netty4ClientHttpRequestFactory`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/client/Netty4ClientHttpRequestFactory.html), using [Netty](https://netty.io/)
 - [`HttpComponentsAsyncClientHttpRequestFactory`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/client/HttpComponentsAsyncClientHttpRequestFactory.html), using [Apache HTTP Async Client](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/index.html)
 
-Non-blocking IO is asynchronous by nature. In order to provide asynchrony for blocking IO you need to register an executor. Not passing an executor will make all network communication synchrnonous, i.e. all futures returned by Riptide will already be completed.
+Non-blocking IO is asynchronous by nature. In order to provide asynchrony for blocking IO you need to register an executor. Not passing an executor will make all network communication synchronous, i.e. all futures returned by Riptide will already be completed.
 
 |                 | Synchronous                | Asynchronous                            |
 |-----------------|----------------------------|-----------------------------------------|

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ In order to configure the thread pool correctly, please refer to
 
 ### Non-blocking IO
 
-Riptide has the notion of an *executor* and a *request factory*. There are two different kinds of request factories:
+Riptide supports two different kinds of request factories:
 
 **[`ClientHttpRequestFactory`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/client/ClientHttpRequestFactory.html)**
 
@@ -244,12 +244,12 @@ The following implementations offer non-blocking IO:
 - [`Netty4ClientHttpRequestFactory`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/client/Netty4ClientHttpRequestFactory.html), using [Netty](https://netty.io/)
 - [`HttpComponentsAsyncClientHttpRequestFactory`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/client/HttpComponentsAsyncClientHttpRequestFactory.html), using [Apache HTTP Async Client](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/index.html)
 
-Non-blocking IO is asynchronous by nature. In order to provide asynchrony for blocking IO you need to register an executor. For synchronous operations it's possible to just pass `Runnable::run`.
+Non-blocking IO is asynchronous by nature. In order to provide asynchrony for blocking IO you need to register an executor. Not passing an executor will make all network communication synchrnonous, i.e. all futures returned by Riptide will already be completed.
 
-|                 | Synchronous                                  | Asynchronous                                      |
-|-----------------|----------------------------------------------|---------------------------------------------------|
-| Blocking IO     | `Runnable::run` + `ClientHttpRequestFactory` | `Executor` + `ClientHttpRequestFactory`           |
-| Non-blocking IO | n/a                                          | `AsyncClientHttpRequestFactory` |
+|                 | Synchronous                | Asynchronous                            |
+|-----------------|----------------------------|-----------------------------------------|
+| Blocking IO     | `ClientHttpRequestFactory` | `Executor` + `ClientHttpRequestFactory` |
+| Non-blocking IO | n/a                        | `AsyncClientHttpRequestFactory`         |
 
 ## Usage
 
@@ -371,7 +371,7 @@ We basically use an intermediate `RestTemplate` as a holder of the special `Clie
 `MockRestServiceServer` manages.
 
 If you are using the [Spring Boot Starter](riptide-spring-boot-starter) the test setup is provided by a convenient annotation `@RiptideClientTest`, 
-see [here](riptide-spring-boot-starter/README.md#testing).
+see [here](riptide-spring-boot-starter#testing).
 
 ## Getting help
 

--- a/riptide-core/src/main/java/org/zalando/riptide/Http.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/Http.java
@@ -31,7 +31,7 @@ public interface Http extends URIStage {
         return new DefaultHttpBuilder();
     }
 
-    interface ExecutorStage {
+    interface ExecutorStage extends RequestFactoryStage {
         RequestFactoryStage executor(Executor executor);
         ConfigurationStage asyncRequestFactory(AsyncClientHttpRequestFactory asyncRequestFactory);
     }

--- a/riptide-core/src/main/java/org/zalando/riptide/Requester.java
+++ b/riptide-core/src/main/java/org/zalando/riptide/Requester.java
@@ -72,15 +72,15 @@ final class Requester extends AttributeStage {
 
     @Override
     public HeaderStage ifModifiedSince(final OffsetDateTime since) {
-        return header(IF_MODIFIED_SINCE, toHttpdate(since));
+        return header(IF_MODIFIED_SINCE, toHttpDate(since));
     }
 
     @Override
     public HeaderStage ifUnmodifiedSince(final OffsetDateTime since) {
-        return header(IF_UNMODIFIED_SINCE, toHttpdate(since));
+        return header(IF_UNMODIFIED_SINCE, toHttpDate(since));
     }
 
-    private String toHttpdate(final OffsetDateTime dateTime) {
+    private String toHttpDate(final OffsetDateTime dateTime) {
         return RFC_1123_DATE_TIME.format(dateTime.atZoneSameInstant(UTC));
     }
 

--- a/riptide-core/src/test/java/org/zalando/riptide/NoBaseUrlTest.java
+++ b/riptide-core/src/test/java/org/zalando/riptide/NoBaseUrlTest.java
@@ -34,7 +34,6 @@ final class NoBaseUrlTest {
     @Test
     void shouldFailOnProvisioningOfNonAbsoluteBaseUri() {
         final Http unit = Http.builder()
-                .executor(Runnable::run)
                 .requestFactory(new SimpleClientHttpRequestFactory())
                 .baseUrl(() -> URI.create(""))
                 .build();

--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -393,6 +393,7 @@ For a complete overview of available properties, they type and default value ple
 | `│   ├── stack-trace-preservation`      |                |                                                  |
 | `│   │   └── enabled`                   | `boolean`      | `true`                                           |
 | `│   ├── threads`                       |                |                                                  |
+| `│   │   ├── enabled`                   | `boolean`      | `true`                                           |
 | `│   │   ├── min-size`                  | `int`          | `1`                                              |
 | `│   │   ├── max-size`                  | `int`          | same as `connections.max-total`                  |
 | `│   │   ├── keep-alive`                | `TimeSpan`     | `1 minute`                                       |
@@ -480,6 +481,7 @@ For a complete overview of available properties, they type and default value ple
 | `        ├── stack-trace-preservation`  |                |                                                  |
 | `        │   └── enabled`               | `boolean`      | see `defaults`                                   |
 | `        ├── threads`                   |                |                                                  |
+| `        │   ├── enabled`               | `boolean`      | see `defaults`                                   |
 | `        │   ├── min-size`              | `int`          | see `defaults`                                   |
 | `        │   ├── max-size`              | `int`          | see `defaults`                                   |
 | `        │   ├── keep-alive`            | `TimeSpan`     | see `defaults`                                   |

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Defaulting.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Defaulting.java
@@ -141,6 +141,7 @@ final class Defaulting {
 
     private static Threads merge(final Threads base, final Threads defaults) {
         return new Threads(
+                either(base.getEnabled(), defaults.getEnabled()),
                 either(base.getMinSize(), defaults.getMinSize()),
                 either(base.getMaxSize(), defaults.getMaxSize()),
                 either(base.getKeepAlive(), defaults.getKeepAlive()),

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/HttpFactory.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/HttpFactory.java
@@ -3,9 +3,11 @@ package org.zalando.riptide.autoconfigure;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.zalando.riptide.Http;
+import org.zalando.riptide.Http.RequestFactoryStage;
 import org.zalando.riptide.Plugin;
 import org.zalando.riptide.UrlResolution;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -17,21 +19,32 @@ final class HttpFactory {
     }
 
     public static Http create(
-            final Executor executor,
+            @Nullable final Executor executor,
             final ClientHttpRequestFactory requestFactory,
             final String baseUrl,
             final UrlResolution urlResolution,
             final List<HttpMessageConverter<?>> converters,
             final List<Plugin> plugins) {
 
-        return Http.builder()
-                .executor(executor)
+
+        return configure(executor)
                 .requestFactory(requestFactory)
                 .baseUrl(baseUrl)
                 .urlResolution(urlResolution)
                 .converters(converters)
                 .plugins(plugins)
                 .build();
+    }
+
+    private static RequestFactoryStage configure(
+            @Nullable final Executor executor) {
+
+        if (executor == null) {
+            return Http.builder();
+        }
+
+        return Http.builder()
+                .executor(executor);
     }
 
 }

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/RiptideProperties.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/RiptideProperties.java
@@ -60,7 +60,7 @@ public final class RiptideProperties {
         );
 
         @NestedConfigurationProperty
-        private Threads threads = new Threads(1, null, TimeSpan.of(1, MINUTES), 0);
+        private Threads threads = new Threads(true, 1, null, TimeSpan.of(1, MINUTES), 0);
 
         @NestedConfigurationProperty
         private Auth auth = new Auth(false, Paths.get("/meta/credentials"));
@@ -214,6 +214,7 @@ public final class RiptideProperties {
     @NoArgsConstructor
     @AllArgsConstructor
     public static final class Threads {
+        private Boolean enabled;
         private Integer minSize;
         private Integer maxSize;
         private TimeSpan keepAlive;

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/DefaultingTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/DefaultingTest.java
@@ -57,7 +57,7 @@ final class DefaultingTest {
     void shouldNotOverwriteProvidedDefaultThreadsMaxSizeWithConnectionsMaxTotal() {
         final RiptideProperties properties = new RiptideProperties();
         final Defaults defaults = new Defaults();
-        defaults.setThreads(new Threads(null, 10, null, null));
+        defaults.setThreads(new Threads(true, null, 10, null, null));
         properties.setDefaults(defaults);
         final RiptideProperties actual = Defaulting.withDefaults(properties);
 

--- a/riptide-spring-boot-autoconfigure/src/test/resources/application-default.yml
+++ b/riptide-spring-boot-autoconfigure/src/test/resources/application-default.yml
@@ -30,6 +30,8 @@ riptide:
     ecb:
       base-url: http://www.ecb.europa.eu
       request-compression.enabled: true
+      threads:
+        enabled: false
       backup-request:
         enabled: true
         delay: 100 milliseconds


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### riptide-core

Executor is now optional and users can configure a `ClientHttpRequestFactory` directly. Not configuring an executor yields synchronous operations, i.e. futures will already be completed.

### riptide-spring-boot-autoconfigure

`threads` got an `enabled` flag (default: `true`) which controls whether a thread pool is configured or not.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
