### PR TITLE
Added CVE-2020-9488 to suppresed list.

### DIFF
--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -17,6 +17,7 @@
 
     <suppress>
         <cve>CVE-2019-12814</cve>
+        <cve>CVE-2020-9488</cve>
     </suppress>
 
     <!-- https://github.com/jeremylong/DependencyCheck/issues/1921 -->


### PR DESCRIPTION
This is LOW scored cve in transitive dependency (slf4j-api), can be triggered by specific configuration of it.

## Motivation and Context
Want to suppress it to unlock the builds that crashing due to presence of this CVE.
