### PR TITLE
Reuse parent classloader for failsafe scheduler threads

### DIFF
--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/CompositeTaskDecorator.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/CompositeTaskDecorator.java
@@ -1,0 +1,20 @@
+package org.zalando.riptide.failsafe;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import net.jodah.failsafe.function.ContextualSupplier;
+
+@AllArgsConstructor
+public class CompositeTaskDecorator implements TaskDecorator {
+
+  private final List<TaskDecorator> decorators;
+
+  @Override
+  public <T> ContextualSupplier<T> decorate(ContextualSupplier<T> supplier) {
+    ContextualSupplier<T> result = supplier;
+    for (TaskDecorator decorator: decorators) {
+      result = decorator.decorate(result);
+    }
+    return result;
+  }
+}

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/soap/PreserveContextClassLoaderTaskDecorator.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/soap/PreserveContextClassLoaderTaskDecorator.java
@@ -1,0 +1,29 @@
+package org.zalando.riptide.soap;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import net.jodah.failsafe.function.ContextualSupplier;
+import org.apiguardian.api.API;
+import org.zalando.riptide.failsafe.TaskDecorator;
+
+/**
+ * @see <a href="https://github.com/zalando/riptide/issues/953">JAXB + ForkJoinPool</a>
+ */
+@API(status = EXPERIMENTAL)
+public class PreserveContextClassLoaderTaskDecorator implements TaskDecorator {
+
+  private final ClassLoader loader = Thread.currentThread().getContextClassLoader();
+
+  @Override
+  public <T> ContextualSupplier<T> decorate(ContextualSupplier<T> supplier) {
+    return context -> {
+      ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+      try {
+        Thread.currentThread().setContextClassLoader(loader);
+        return supplier.get(context);
+      } finally {
+        Thread.currentThread().setContextClassLoader(originalClassLoader);
+      }
+    };
+  }
+}


### PR DESCRIPTION
https://github.com/zalando/riptide/issues/953

Supply failsafe plugin with task decorator to reuse parent class loader for scheduler threads

## Description
PreserveContextClassLoaderTaskDecorator ei

## Motivation and Context
See https://github.com/zalando/riptide/issues/953

Essentially JAXBContext invoked within Failsafe ForkJoinPool will use system class loader, which does not work as expected in combination with Spring Boot (please see related issue).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
