### PR TITLE
Use plural timeunit for retry.max-duration example

### DIFF
--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -273,7 +273,7 @@ riptide:
         enabled: true
         fixed-delay: 50 milliseconds
         max-retries: 5
-        max-duration: 2 second
+        max-duration: 2 seconds
         jitter: 25 milliseconds
       circuit-breaker:
         enabled: true


### PR DESCRIPTION
## Description
In the example given retry.max-duration was `2 second` which is changed to `2 seconds` to be consistent with other values.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Improve documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
