### PR TITLE
Suppressed log4j cve

### DIFF
--- a/cve-suppressions.xml
+++ b/cve-suppressions.xml
@@ -32,4 +32,9 @@
         <cve>CVE-2013-7315</cve>
         <cve>CVE-2014-0054</cve>
     </suppress>
+
+    <!-- https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot -->
+    <suppress>
+        <cve>CVE-2021-44228</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Description
Suppress false positive. Restore builds. 


## Motivation and Context
Riptide doesn't depend on log4j-core containing vulnerability. log4j-api is transient dependency from spring, but falsely flagged by vulnerability checker. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
