### PR TITLE
Switched identification of current version to maven

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -4,7 +4,7 @@
 
 ./mvnw scm:check-local-modification
 
-current=$(git describe --abbrev=0 || echo 0.0.0)
+current=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version --non-recursive | grep -v INFO || echo 0.0.0)
 release=$(semver ${current} -i $1 --preid RC)
 next=$(semver ${release} -i minor)
 


### PR DESCRIPTION
## Motivation and Context
git approach is not identifying release 3.0 correctly. Switching to maven for identification directly from pom file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
