### PR TITLE
Included opentelemetry plugin in riptide bom

### DIFF
--- a/riptide-bom/pom.xml
+++ b/riptide-bom/pom.xml
@@ -85,6 +85,11 @@
             </dependency>
             <dependency>
                 <groupId>org.zalando</groupId>
+                <artifactId>riptide-opentelemetry</artifactId>
+                <version>3.2.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.zalando</groupId>
                 <artifactId>riptide-problem</artifactId>
                 <version>3.2.0-SNAPSHOT</version>
             </dependency>


### PR DESCRIPTION
## Description
Ref #1166 

## Motivation and Context
To allow usage of riptide-opentelemetry with BOM imports in maven and Gradle, instead of direct version specification. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
