### PR TITLE
Reuse spring classloader for failsafe scheduler threads

### DIFF
--- a/riptide-failsafe/src/main/java/org/zalando/riptide/soap/PreserveContextClassLoaderTaskDecorator.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/soap/PreserveContextClassLoaderTaskDecorator.java
@@ -14,14 +14,14 @@ public final class PreserveContextClassLoaderTaskDecorator implements TaskDecora
 
     @Override
     public <T> ContextualSupplier<T> decorate(final ContextualSupplier<T> supplier) {
-        final Thread currentThread = Thread.currentThread();
-        final ClassLoader original = currentThread.getContextClassLoader();
+        final ClassLoader invokingThreadCL = Thread.currentThread().getContextClassLoader();
         return context -> {
+            final ClassLoader originalCL = Thread.currentThread().getContextClassLoader();
             try {
-                currentThread.setContextClassLoader(original);
+                Thread.currentThread().setContextClassLoader(invokingThreadCL);
                 return supplier.get(context);
             } finally {
-                currentThread.setContextClassLoader(original);
+                Thread.currentThread().setContextClassLoader(originalCL);
             }
         };
     }


### PR DESCRIPTION
Contributes to https://github.com/zalando/riptide/issues/953

## Description
Fix `PreserveContextClassLoaderTaskDecorator` in order to set a class loader from invoking thread to a runner thread.

## Motivation and Context
Previously this task decorator has been created to resolve above mentioned issue. However there's a bug in this task decorator which prevents it from working as expected. The code in labmda should assign class loader to runner thread but it was assigning it to invoking thread, which does not make sense as it's the same thread which the class loader is being obtained from.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
