### PR TITLE
OpenTelemetry: provided dependencies

### DIFF
--- a/riptide-opentelemetry/pom.xml
+++ b/riptide-opentelemetry/pom.xml
@@ -30,11 +30,13 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
             <version>${opentelemetry.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
             <version>${opentelemetry-semconv.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
OpenTelemetry: set the dependencies to "provided" to avoid problems with incompatible API changes in opentelemetry