### PR TITLE
add OpenTelemetry metrics

### DIFF
--- a/riptide-opentelemetry/pom.xml
+++ b/riptide-opentelemetry/pom.xml
@@ -18,13 +18,17 @@
 
     <properties>
         <opentelemetry.version>1.22.0</opentelemetry.version>
-        <opentelemetry-semconv.version>${opentelemetry.version}-alpha</opentelemetry-semconv.version>
+        <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>riptide-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>riptide-micrometer</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -34,7 +38,17 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
-            <version>${opentelemetry-semconv.version}</version>
+            <version>${opentelemetry-alpha.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-micrometer-1.5</artifactId>
+            <version>${opentelemetry-alpha.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/OpenTelemetryPlugin.java
+++ b/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/OpenTelemetryPlugin.java
@@ -1,5 +1,7 @@
 package org.zalando.riptide.opentelemetry;
 
+import javax.annotation.Nonnull;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Multimaps;
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -10,12 +12,14 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry;
 import org.springframework.http.client.ClientHttpResponse;
 import org.zalando.fauxpas.ThrowingBiConsumer;
 import org.zalando.riptide.Attribute;
 import org.zalando.riptide.Plugin;
 import org.zalando.riptide.RequestArguments;
 import org.zalando.riptide.RequestExecution;
+import org.zalando.riptide.micrometer.MicrometerPlugin;
 import org.zalando.riptide.opentelemetry.span.CompositeSpanDecorator;
 import org.zalando.riptide.opentelemetry.span.ErrorSpanDecorator;
 import org.zalando.riptide.opentelemetry.span.HttpMethodSpanDecorator;
@@ -30,7 +34,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.BiConsumer;
-import javax.annotation.Nonnull;
 
 public class OpenTelemetryPlugin implements Plugin {
 
@@ -61,6 +64,9 @@ public class OpenTelemetryPlugin implements Plugin {
         this.tracer = telemetry.getTracer("riptide-opentelemetry");
         this.propagator = telemetry.getPropagators().getTextMapPropagator();
         this.spanDecorator = spanDecorator;
+
+        // todo should OpenTelemetryPlugin extend MicrometerPlugin
+        new MicrometerPlugin(OpenTelemetryMeterRegistry.create(telemetry));
     }
 
     public OpenTelemetryPlugin withSpanDecorators(final SpanDecorator... decorators) {


### PR DESCRIPTION
Try out how to add OpenTelemetry metrics.

It seems a bit redundant to reimplement all metrics using otel API, so trying to leverage the existing bridge.

I'm ussure how to best integrate the MicrometerPlugin. I would create a composite Plugin, but this doesn't work, because users call the OpenTelemetryPlugin constructor directly.