### PR TITLE
Remove jakartaee-api in favor of jakarta.xml.bind-api

### DIFF
--- a/riptide-core/pom.xml
+++ b/riptide-core/pom.xml
@@ -58,9 +58,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.1.0</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
We only need to import `jakarta.xml.bind-api` rather than the full-blown `jakartaee-api`, which is only used in `riptide-core` tests.

This also addresses https://github.com/zalando/riptide/pull/1475.

## Description
Replaced test dependency `jakarta.platform:jakartaee-api` with `jakarta.xml.bind:jakarta.xml.bind-api`.

## Motivation and Context
Addresses https://github.com/zalando/riptide/pull/1475.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
