### PR TITLE
Fix cache auto configuration

### DIFF
--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -200,9 +200,9 @@ Required when `caching` is enabled.
 
 ```xml
 <dependency>
-    <groupId>org.apache.httpcomponents</groupId>
-    <artifactId>httpclient-cache</artifactId>
-    <version>${httpclient.version}</version>
+    <groupId>org.apache.httpcomponents.client5</groupId>
+    <artifactId>httpclient5-cache</artifactId>
+    <version>${httpclient5.version}</version>
 </dependency>
 ```
 

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/RiptideProperties.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/RiptideProperties.java
@@ -4,10 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.apache.hc.client5.http.impl.cache.CacheConfig;
+import org.apache.hc.core5.util.TimeValue;
 import org.apiguardian.api.API;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.stereotype.Component;
 import org.zalando.riptide.UrlResolution;
 import org.zalando.riptide.autoconfigure.RiptideProperties.Caching.Heuristic;
 import org.zalando.riptide.autoconfigure.RiptideProperties.CertificatePinning.Keystore;
@@ -35,6 +36,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Component
 @ConfigurationProperties(prefix = "riptide")
 public final class RiptideProperties {
 
@@ -46,6 +48,11 @@ public final class RiptideProperties {
     @NoArgsConstructor
     @AllArgsConstructor
     public static final class Defaults {
+        // These constants where copied from org.apache.hc.client5.http.impl.cache.CacheConfig
+        private static final int DEFAULT_MAX_OBJECT_SIZE_BYTES = 8192;
+        private static final int DEFAULT_MAX_CACHE_ENTRIES = 1000;
+        private static final float DEFAULT_HEURISTIC_COEFFICIENT = 0.1F;
+        private static final TimeValue DEFAULT_HEURISTIC_LIFETIME = TimeValue.ZERO_MILLISECONDS;
 
         private UrlResolution urlResolution = UrlResolution.RFC;
 
@@ -112,12 +119,12 @@ public final class RiptideProperties {
                 false,
                 false,
                 null,
-                CacheConfig.DEFAULT_MAX_OBJECT_SIZE_BYTES,
-                CacheConfig.DEFAULT_MAX_CACHE_ENTRIES,
+                DEFAULT_MAX_OBJECT_SIZE_BYTES,
+                DEFAULT_MAX_CACHE_ENTRIES,
                 new Heuristic(
                         false,
-                        CacheConfig.DEFAULT_HEURISTIC_COEFFICIENT,
-                        TimeSpan.of(CacheConfig.DEFAULT_HEURISTIC_LIFETIME.toSeconds(), SECONDS)
+                        DEFAULT_HEURISTIC_COEFFICIENT,
+                        TimeSpan.of(DEFAULT_HEURISTIC_LIFETIME.toSeconds(), SECONDS)
                 )
         );
 

--- a/riptide-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/riptide-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,2 @@
 org.zalando.riptide.autoconfigure.OpenTracingFlowIdAutoConfiguration
 org.zalando.riptide.autoconfigure.RiptideAutoConfiguration
-org.zalando.riptide.autoconfigure.RiptideTestAutoConfiguration

--- a/riptide-spring-boot-autoconfigure/src/test/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/riptide-spring-boot-autoconfigure/src/test/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.zalando.riptide.autoconfigure.RiptideTestAutoConfiguration


### PR DESCRIPTION
Using Riptide without caching enabled must not require `httpclient5-cache`.

## Description
* Fixed `RiptideProperties` such that it does not require `org.apache.hc.client5.http.impl.cache.CacheConfig`.
* Fixed `org.springframework.boot.autoconfigure.AutoConfiguration.imports` to have separate configs for main and test (otherwise, production code would require `MockRestServiceServer` to be in class path)
* Updated README.md to use `httpclient5-cache` instead of `httpclient-cache`.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
