### PR TITLE
add executor service param

### DIFF
--- a/riptide-failsafe/README.md
+++ b/riptide-failsafe/README.md
@@ -129,7 +129,7 @@ Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
         .withExecutor(Executors.newFixedThreadPool(2)))
     .build();
 ```
-```suggestion
+
 If no executor is specified, the default executor configured by `Failsafe` is used. See [Failsafe DelegatingScheduler class](https://github.com/failsafe-lib/failsafe/blob/master/core/src/main/java/dev/failsafe/internal/util/DelegatingScheduler.java#L111), 
 and also [Failsafe documentation](https://failsafe.dev/async-execution/#executorservice-configuration) for more information.
 

--- a/riptide-failsafe/README.md
+++ b/riptide-failsafe/README.md
@@ -59,8 +59,9 @@ Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
                 .withFailureThreshold(3, 10)
                 .withSuccessThreshold(5)
                 .withDelay(Duration.ofMinutes(1))
-                .build()))
-        .build();
+                .build())
+        .withExecutor(Executors.newFixedThreadPool(2)))
+    .build();
 ```
 
 Please visit the [Failsafe readme](https://github.com/jhalterman/failsafe#readme) in order to see possible configurations. 
@@ -112,6 +113,25 @@ Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
         .withPolicy(new BackupRequest(1, SECONDS)))
     .build();
 ```
+
+### Custom executor
+
+The `withExecutor` method allows to specify custom `ExecutorService`, it will be used to perform asynchronous executions and listener callbacks:
+
+```java
+Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
+    .plugin(new FailsafePlugin()
+        .withPolicy(
+            CircuitBreaker.<ClientHttpResponse>builder()
+                .withFailureThreshold(3, 10)
+                .withSuccessThreshold(5)
+                .withDelay(Duration.ofMinutes(1))
+                .build())
+        .withExecutor(Executors.newFixedThreadPool(2)))
+    .build();
+```
+
+See [Failsafe documentation](https://failsafe.dev/async-execution/#executorservice-configuration) for more information.
 
 ## Usage
 

--- a/riptide-failsafe/README.md
+++ b/riptide-failsafe/README.md
@@ -116,7 +116,7 @@ Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
 
 ### Custom executor
 
-The `withExecutor` method allows to specify custom `ExecutorService`, it will be used to perform asynchronous executions and listener callbacks:
+The `withExecutor` method allows to specify custom `ExecutorService`, it will be used to perform asynchronous executions and listen for callbacks:
 
 ```java
 Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
@@ -130,8 +130,8 @@ Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
         .withExecutor(Executors.newFixedThreadPool(2)))
     .build();
 ```
-
-See [Failsafe documentation](https://failsafe.dev/async-execution/#executorservice-configuration) for more information.
+If no executor is specified - default executor configured by `Failsafe` will be used, see [Failsafe DelegatingScheduler class](https://github.com/failsafe-lib/failsafe/blob/master/core/src/main/java/dev/failsafe/internal/util/DelegatingScheduler.java#L111), 
+see also [Failsafe documentation](https://failsafe.dev/async-execution/#executorservice-configuration) for more information.
 
 ## Usage
 

--- a/riptide-failsafe/README.md
+++ b/riptide-failsafe/README.md
@@ -133,6 +133,9 @@ Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
 If no executor is specified, the default executor configured by `Failsafe` is used. See [Failsafe DelegatingScheduler class](https://github.com/failsafe-lib/failsafe/blob/master/core/src/main/java/dev/failsafe/internal/util/DelegatingScheduler.java#L111), 
 and also [Failsafe documentation](https://failsafe.dev/async-execution/#executorservice-configuration) for more information.
 
+**Beware** when specifying a custom `ExecutorService` - the `ExecutorService` should have a core pool size or parallelism 
+of at least 2 in order for [timeouts](https://github.com/failsafe-lib/failsafe/blob/master/core/src/main/java/dev/failsafe/Timeout.java) to work.
+
 ## Usage
 
 Given the failsafe plugin was configured as shown in the last section: A regular call like the following will now be

--- a/riptide-failsafe/README.md
+++ b/riptide-failsafe/README.md
@@ -59,8 +59,7 @@ Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
                 .withFailureThreshold(3, 10)
                 .withSuccessThreshold(5)
                 .withDelay(Duration.ofMinutes(1))
-                .build())
-        .withExecutor(Executors.newFixedThreadPool(2)))
+                .build()))
     .build();
 ```
 

--- a/riptide-failsafe/README.md
+++ b/riptide-failsafe/README.md
@@ -133,8 +133,9 @@ Http.builder().requestFactory(new HttpComponentsClientHttpRequestFactory())
 If no executor is specified, the default executor configured by `Failsafe` is used. See [Failsafe DelegatingScheduler class](https://github.com/failsafe-lib/failsafe/blob/master/core/src/main/java/dev/failsafe/internal/util/DelegatingScheduler.java#L111), 
 and also [Failsafe documentation](https://failsafe.dev/async-execution/#executorservice-configuration) for more information.
 
-**Beware** when specifying a custom `ExecutorService` - the `ExecutorService` should have a core pool size or parallelism 
-of at least 2 in order for [timeouts](https://github.com/failsafe-lib/failsafe/blob/master/core/src/main/java/dev/failsafe/Timeout.java) to work.
+**Beware** when specifying a custom `ExecutorService`: 
+1. The `ExecutorService` should have a core pool size or parallelism of at least 2 in order for [timeouts](https://github.com/failsafe-lib/failsafe/blob/master/core/src/main/java/dev/failsafe/Timeout.java) to work
+2. In general, it is not recommended to specify the same `ExecutorService` for multiple `Http` clients 
 
 ## Usage
 

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
@@ -11,6 +11,7 @@ import org.zalando.riptide.Plugin;
 import org.zalando.riptide.RequestArguments;
 import org.zalando.riptide.RequestExecution;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
@@ -48,7 +49,7 @@ public final class FailsafePlugin implements Plugin {
         return new FailsafePlugin(policies.append(policy), decorators, executorService);
     }
 
-    public FailsafePlugin withExecutor(final ExecutorService executorService) {
+    public FailsafePlugin withExecutor(@Nullable final ExecutorService executorService) {
         return new FailsafePlugin(policies, decorators, executorService);
     }
 

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
@@ -66,7 +66,6 @@ public final class FailsafePlugin implements Plugin {
                 return execution.execute(arguments);
             } else if (executorService != null) {
               return Failsafe.with(select(arguments))
-                        // TODO: need threads count validation? see with method doc
                         .with(executorService)
                         .getStageAsync(decorate(execution, arguments));
             } else {

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
@@ -55,7 +55,7 @@ public final class FailsafePlugin implements Plugin {
     public FailsafePlugin withExecutor(@Nullable final ExecutorService executorService) {
         if (executorService instanceof ThreadPoolExecutor
                 && ((ThreadPoolExecutor) executorService).getCorePoolSize() == 1) {
-            log.warn("The executorService should have a core pool size or parallelism of at least 2 in order for timeouts to work, " +
+            log.warn("The custom executorService should have a core pool size or parallelism of at least 2 in order for timeouts to work, " +
                     "see dev.failsafe.Failsafe documentation for more details");
         }
         return new FailsafePlugin(policies, decorators, executorService);

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
@@ -49,7 +49,7 @@ public final class FailsafePlugin implements Plugin {
         return new FailsafePlugin(policies.append(policy), decorators, executorService);
     }
 
-    public FailsafePlugin withExecutorService(final ExecutorService executorService) {
+    public FailsafePlugin withExecutor(final ExecutorService executorService) {
         return new FailsafePlugin(policies, decorators, executorService);
     }
 

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
@@ -4,6 +4,7 @@ import dev.failsafe.Failsafe;
 import dev.failsafe.Policy;
 import dev.failsafe.function.ContextualSupplier;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apiguardian.api.API;
 import org.organicdesign.fp.collections.ImList;
 import org.springframework.http.client.ClientHttpResponse;
@@ -15,6 +16,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Predicate;
 
 import static java.util.stream.Collectors.toList;
@@ -23,6 +25,7 @@ import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.organicdesign.fp.StaticImports.vec;
 import static org.zalando.riptide.Attributes.RETRIES;
 
+@Slf4j
 @API(status = MAINTAINED)
 @AllArgsConstructor(access = PRIVATE)
 public final class FailsafePlugin implements Plugin {
@@ -50,6 +53,11 @@ public final class FailsafePlugin implements Plugin {
     }
 
     public FailsafePlugin withExecutor(@Nullable final ExecutorService executorService) {
+        if (executorService instanceof ThreadPoolExecutor
+                && ((ThreadPoolExecutor) executorService).getCorePoolSize() == 1) {
+            log.warn("The executorService should have a core pool size or parallelism of at least 2 in order for timeouts to work, " +
+                    "see dev.failsafe.Failsafe documentation for more details");
+        }
         return new FailsafePlugin(policies, decorators, executorService);
     }
 

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/FailsafePlugin.java
@@ -66,7 +66,7 @@ public final class FailsafePlugin implements Plugin {
             } else if (executorService != null) {
               return Failsafe.with(select(arguments))
                         // TODO: need threads count validation? see with method doc
-                        .with(executorService) // according to https://failsafe.dev/async-execution/#custom-schedulers
+                        .with(executorService)
                         .getStageAsync(decorate(execution, arguments));
             } else {
                 return Failsafe.with(select(arguments))

--- a/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/FailsafePluginCustomExecutorTest.java
+++ b/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/FailsafePluginCustomExecutorTest.java
@@ -8,13 +8,13 @@ import lombok.extern.slf4j.Slf4j;
 import okhttp3.mockwebserver.MockWebServer;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.zalando.riptide.Http;
 import org.zalando.riptide.httpclient.ApacheClientHttpRequestFactory;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
@@ -29,11 +29,9 @@ import java.util.stream.IntStream;
 
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.zalando.riptide.PassRoute.pass;
 import static org.zalando.riptide.failsafe.MockWebServerUtil.emptyMockResponse;
 import static org.zalando.riptide.failsafe.MockWebServerUtil.getBaseUrl;
@@ -42,7 +40,7 @@ import static org.zalando.riptide.failsafe.MockWebServerUtil.verify;
 @Slf4j
 final class FailsafePluginCustomExecutorTest {
 
-    public static class CountingExecutorService extends ThreadPoolExecutor {
+    private static class CountingExecutorService extends ThreadPoolExecutor {
         AtomicInteger counter = new AtomicInteger();
 
         public CountingExecutorService(int corePoolSize,
@@ -59,7 +57,7 @@ final class FailsafePluginCustomExecutorTest {
         }
 
         @Override
-        public void execute(@NotNull Runnable command) {
+        public void execute(@Nonnull Runnable command) {
             super.execute(() -> {
                 log.info("Failsafe executor runnable");
                 counter.incrementAndGet();
@@ -133,7 +131,7 @@ final class FailsafePluginCustomExecutorTest {
                 unit.get("/foo")
                         .call(pass())::join);
 
-        assertThat(exception.getCause(), is(instanceOf(TimeoutExceededException.class)));
+        assertTrue(exception.getCause() instanceof TimeoutExceededException);
 
         verify(server, 1, "/foo");
         assertEquals(1, countingExecutor.counter.get());

--- a/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/FailsafePluginCustomExecutorTest.java
+++ b/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/FailsafePluginCustomExecutorTest.java
@@ -1,0 +1,129 @@
+package org.zalando.riptide.failsafe;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.failsafe.Timeout;
+import dev.failsafe.TimeoutExceededException;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.zalando.riptide.Http;
+import org.zalando.riptide.httpclient.ApacheClientHttpRequestFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.zalando.riptide.PassRoute.pass;
+import static org.zalando.riptide.failsafe.MockWebServerUtil.emptyMockResponse;
+import static org.zalando.riptide.failsafe.MockWebServerUtil.getBaseUrl;
+import static org.zalando.riptide.failsafe.MockWebServerUtil.verify;
+
+@Slf4j
+final class FailsafePluginCustomExecutorTest {
+
+    public static class CountingExecutorService extends ThreadPoolExecutor {
+        AtomicInteger counter = new AtomicInteger();
+        public CountingExecutorService (int corePoolSize,
+                                  int maximumPoolSize,
+                                  long keepAliveTime,
+                                  TimeUnit unit,
+                                  BlockingQueue<Runnable> workQueue) {
+            super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue,
+                    Executors.defaultThreadFactory());
+        }
+
+        void resetCounter() {
+            counter.set(0);
+        }
+
+        @Override
+        public void execute(@NotNull Runnable command) {
+            counter.incrementAndGet();
+            log.info("!!!!!!!!!!!!");
+            super.execute(command);
+        }
+    }
+
+    private final MockWebServer server = new MockWebServer();
+
+    private final CloseableHttpClient client = HttpClientBuilder.create().build();
+    private final ApacheClientHttpRequestFactory factory = new ApacheClientHttpRequestFactory(client);
+
+    private final CountingExecutorService countingExecutor = new CountingExecutorService(1, 1,
+            0L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>());
+
+    private final Http unit = Http.builder()
+            .executor(newSingleThreadExecutor())
+            .requestFactory(factory)
+            .baseUrl(getBaseUrl(server))
+            .converter(createJsonConverter())
+            .plugin(new FailsafePlugin()
+                    .withPolicy(Timeout.of(Duration.ofSeconds(1)))
+                    .withExecutor(countingExecutor)
+            )
+            .build();
+
+    private static MappingJackson2HttpMessageConverter createJsonConverter() {
+        final MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(createObjectMapper());
+        return converter;
+    }
+
+    private static ObjectMapper createObjectMapper() {
+        return new ObjectMapper().findAndRegisterModules()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        client.close();
+        server.shutdown();
+        countingExecutor.resetCounter();
+    }
+
+    @Test
+    void shouldNotTimeout() {
+        server.enqueue(emptyMockResponse());
+
+        unit.get("/foo")
+                .call(pass())
+                .join();
+        verify(server, 1, "/foo");
+        assertEquals(1, countingExecutor.counter.get());
+    }
+
+    @Test
+    void shouldTimeout() {
+        server.enqueue(emptyMockResponse().setHeadersDelay(2, SECONDS));
+
+        final CompletionException exception = assertThrows(CompletionException.class,
+                unit.get("/foo")
+                        .call(pass())::join);
+
+        assertThat(exception.getCause(), is(instanceOf(TimeoutExceededException.class)));
+        verify(server, 1, "/foo");
+        assertEquals(1, countingExecutor.counter.get());
+    }
+
+}

--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -606,9 +606,16 @@ The following table shows all beans with their respective name (for the `example
 | `exampleFaultClassifier`          | `FaultClassifier`                             |
 | `exampleCircuitBreakerListener`   | `CircuitBreakerListener`                      |
 | `exampleAuthorizationProvider`    | `AuthorizationProvider`                       |
+| `exampleRetryPolicyExecutorService`    | `ExecutorService`                       |
+| `exampleCircuitBreakerExecutorService`    | `ExecutorService`                       |
+| `exampleBackupRequestExecutorService`    | `ExecutorService`                       |
+| `exampleTimeoutExecutorService`    | `ExecutorService`                       |
 
 If you override a bean then all of its dependencies (see the [graph](#customization)), will **not** be registered,
 unless required by some other bean.
+
+You can specify `ExecutorService` for each `FailsafePlugin` by providing beans with the following naming convention:
+`exampleRetryPolicyExecutorService`, `exampleCircuitBreakerExecutorService`, `exampleBackupRequestExecutorService`, `exampleTimeoutExecutorService`.
 
 In case you need more than one custom plugin, please use `Plugin.composite(Plugin...)`.
 

--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -587,29 +587,29 @@ public ClientHttpMessageConverters exampleHttpMessageConverters() {
 
 The following table shows all beans with their respective name (for the `example` client) and type:
 
-| Bean Name                         | Bean Type                                     |
-|-----------------------------------|-----------------------------------------------|
-| `exampleHttp`                     | `Http`                                        |
-| `exampleBaseURL`                  | `BaseURL` (effectively a `Supplier<URI>`)     |
-| `exampleClientHttpRequestFactory` | `ClientHttpRequestFactory`                    |
-| `exampleHttpMessageConverters`    | `ClientHttpMessageConverters`                 |
-| `exampleHttpClient`               | `HttpClient`                                  |
-| `exampleExecutorService`          | `ExecutorService`                             |
-| `exampleFailsafePlugin`           | `FailsafePlugin`                              |
-| `exampleMicrometerPlugin`         | `MicrometerPlugin`                            |
-| `exampleOriginalStackTracePlugin` | `OriginalStackTracePlugin`                    |
-| `examplePlugin`                   | `Plugin` (optional, additional custom plugin) |
-| `exampleScheduledExecutorService` | `ScheduledExecutorService`                    |
-| `exampleRetryPolicy`              | `RetryPolicy`                                 |
-| `exampleCircuitBreaker`           | `CircuitBreaker`                              |
-| `exampleRetryListener`            | `RetryListener`                               |
-| `exampleFaultClassifier`          | `FaultClassifier`                             |
-| `exampleCircuitBreakerListener`   | `CircuitBreakerListener`                      |
-| `exampleAuthorizationProvider`    | `AuthorizationProvider`                       |
-| `exampleRetryPolicyExecutorService`    | `ExecutorService`                       |
-| `exampleCircuitBreakerExecutorService`    | `ExecutorService`                       |
-| `exampleBackupRequestExecutorService`    | `ExecutorService`                       |
-| `exampleTimeoutExecutorService`    | `ExecutorService`                       |
+| Bean Name                              | Bean Type                                     |
+|----------------------------------------|-----------------------------------------------|
+| `exampleHttp`                          | `Http`                                        |
+| `exampleBaseURL`                       | `BaseURL` (effectively a `Supplier<URI>`)     |
+| `exampleClientHttpRequestFactory`      | `ClientHttpRequestFactory`                    |
+| `exampleHttpMessageConverters`         | `ClientHttpMessageConverters`                 |
+| `exampleHttpClient`                    | `HttpClient`                                  |
+| `exampleExecutorService`               | `ExecutorService`                             |
+| `exampleFailsafePlugin`                | `FailsafePlugin`                              |
+| `exampleMicrometerPlugin`              | `MicrometerPlugin`                            |
+| `exampleOriginalStackTracePlugin`      | `OriginalStackTracePlugin`                    |
+| `examplePlugin`                        | `Plugin` (optional, additional custom plugin) |
+| `exampleScheduledExecutorService`      | `ScheduledExecutorService`                    |
+| `exampleRetryPolicy`                   | `RetryPolicy`                                 |
+| `exampleCircuitBreaker`                | `CircuitBreaker`                              |
+| `exampleRetryListener`                 | `RetryListener`                               |
+| `exampleFaultClassifier`               | `FaultClassifier`                             |
+| `exampleCircuitBreakerListener`        | `CircuitBreakerListener`                      |
+| `exampleAuthorizationProvider`         | `AuthorizationProvider`                       |
+| `exampleRetryPolicyExecutorService`    | `ExecutorService`                             |
+| `exampleCircuitBreakerExecutorService` | `ExecutorService`                             |
+| `exampleBackupRequestExecutorService`  | `ExecutorService`                             |
+| `exampleTimeoutExecutorService`        | `ExecutorService`                             |
 
 If you override a bean then all of its dependencies (see the [graph](#customization)), will **not** be registered,
 unless required by some other bean.

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
@@ -408,18 +408,14 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
             final String pluginId = registry.registerIfAbsent(name(id, CircuitBreaker.class, FailsafePlugin.class),
                     () -> {
                         var executorService = registry.find(name(id, "CircuitBreaker", ExecutorService.class));
+                        var executorServiceRef = executorService.map(Registry::ref).orElse(null);
 
                         log.debug("Client [{}]: Registering [CircuitBreakerFailsafePlugin]", id);
-                        return executorService.map(executorServiceBeanName -> genericBeanDefinition(FailsafePluginFactory.class)
+                        return genericBeanDefinition(FailsafePluginFactory.class)
                                         .setFactoryMethod("createCircuitBreakerPlugin")
                                         .addConstructorArgValue(registerCircuitBreaker(id, client))
                                         .addConstructorArgValue(createTaskDecorators(id, client))
-                                        .addConstructorArgValue(ref(executorServiceBeanName)))
-                                .orElseGet(() -> genericBeanDefinition(FailsafePluginFactory.class)
-                                        .setFactoryMethod("createCircuitBreakerPlugin")
-                                        .addConstructorArgValue(registerCircuitBreaker(id, client))
-                                        .addConstructorArgValue(createTaskDecorators(id, client))
-                                        .addConstructorArgValue(null));
+                                        .addConstructorArgValue(executorServiceRef);
                     });
             return Optional.of(pluginId);
         }
@@ -430,18 +426,14 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
         if (client.getRetry().getEnabled()) {
             final String pluginId = registry.registerIfAbsent(name(id, "RetryPolicy", FailsafePlugin.class), () -> {
                 var executorService = registry.find(name(id, "RetryPolicy", ExecutorService.class));
+                var executorServiceRef = executorService.map(Registry::ref).orElse(null);
 
                 log.debug("Client [{}]: Registering [RetryPolicyFailsafePlugin]", id);
-                return executorService.map(executorServiceBeanName -> genericBeanDefinition(FailsafePluginFactory.class)
+                return genericBeanDefinition(FailsafePluginFactory.class)
                                 .setFactoryMethod("createRetryFailsafePlugin")
                                 .addConstructorArgValue(client)
                                 .addConstructorArgValue(createTaskDecorators(id, client))
-                                .addConstructorArgValue(ref(executorServiceBeanName)))
-                        .orElseGet(() -> genericBeanDefinition(FailsafePluginFactory.class)
-                                .setFactoryMethod("createRetryFailsafePlugin")
-                                .addConstructorArgValue(client)
-                                .addConstructorArgValue(createTaskDecorators(id, client))
-                                .addConstructorArgValue(null));
+                                .addConstructorArgValue(executorServiceRef);
             });
             return Optional.of(pluginId);
         }
@@ -465,17 +457,14 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
             final String pluginId = registry.registerIfAbsent(name(id, BackupRequest.class, FailsafePlugin.class),
                     () -> {
                         var executorService = registry.find(name(id, "BackupRequest", ExecutorService.class));
+                        var executorServiceRef = executorService.map(Registry::ref).orElse(null);
+
                         log.debug("Client [{}]: Registering [BackupRequestFailsafePlugin]", id);
-                        return executorService.map(executorServiceBeanName -> genericBeanDefinition(FailsafePluginFactory.class)
+                        return genericBeanDefinition(FailsafePluginFactory.class)
                                         .setFactoryMethod("createBackupRequestPlugin")
                                         .addConstructorArgValue(client)
                                         .addConstructorArgValue(createTaskDecorators(id, client))
-                                        .addConstructorArgValue(ref(executorServiceBeanName)))
-                                .orElseGet(() -> genericBeanDefinition(FailsafePluginFactory.class)
-                                        .setFactoryMethod("createBackupRequestPlugin")
-                                        .addConstructorArgValue(client)
-                                        .addConstructorArgValue(createTaskDecorators(id, client))
-                                        .addConstructorArgValue(null));
+                                        .addConstructorArgValue(executorServiceRef);
                     });
             return Optional.of(pluginId);
         }
@@ -486,18 +475,14 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
         if (client.getTimeouts().getEnabled()) {
             final String pluginId = registry.registerIfAbsent(name(id, Timeout.class, FailsafePlugin.class), () -> {
                 var executorService = registry.find(name(id, "Timeout", ExecutorService.class));
+                var executorServiceRef = executorService.map(Registry::ref).orElse(null);
 
                 log.debug("Client [{}]: Registering [TimeoutFailsafePlugin]", id);
-                return executorService.map(executorServiceBeanName -> genericBeanDefinition(FailsafePluginFactory.class)
+                return genericBeanDefinition(FailsafePluginFactory.class)
                                 .setFactoryMethod("createTimeoutPlugin")
                                 .addConstructorArgValue(client)
                                 .addConstructorArgValue(createTaskDecorators(id, client))
-                                .addConstructorArgValue(ref(executorServiceBeanName)))
-                        .orElseGet(() -> genericBeanDefinition(FailsafePluginFactory.class)
-                                .setFactoryMethod("createTimeoutPlugin")
-                                .addConstructorArgValue(client)
-                                .addConstructorArgValue(createTaskDecorators(id, client))
-                                .addConstructorArgValue(null));
+                                .addConstructorArgValue(executorServiceRef);
             });
             return Optional.of(pluginId);
         }

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
@@ -407,11 +407,19 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
         if (client.getCircuitBreaker().getEnabled()) {
             final String pluginId = registry.registerIfAbsent(name(id, CircuitBreaker.class, FailsafePlugin.class),
                     () -> {
+                        var executorService = registry.find(name(id, "CircuitBreaker", ExecutorService.class));
+
                         log.debug("Client [{}]: Registering [CircuitBreakerFailsafePlugin]", id);
-                        return genericBeanDefinition(FailsafePluginFactory.class)
-                                .setFactoryMethod("createCircuitBreakerPlugin")
-                                .addConstructorArgValue(registerCircuitBreaker(id, client))
-                                .addConstructorArgValue(createTaskDecorators(id, client));
+                        return executorService.map(executorServiceBeanName -> genericBeanDefinition(FailsafePluginFactory.class)
+                                        .setFactoryMethod("createCircuitBreakerPlugin")
+                                        .addConstructorArgValue(registerCircuitBreaker(id, client))
+                                        .addConstructorArgValue(createTaskDecorators(id, client))
+                                        .addConstructorArgValue(ref(executorServiceBeanName)))
+                                .orElseGet(() -> genericBeanDefinition(FailsafePluginFactory.class)
+                                        .setFactoryMethod("createCircuitBreakerPlugin")
+                                        .addConstructorArgValue(registerCircuitBreaker(id, client))
+                                        .addConstructorArgValue(createTaskDecorators(id, client))
+                                        .addConstructorArgValue(null));
                     });
             return Optional.of(pluginId);
         }
@@ -421,23 +429,19 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
     private Optional<String> registerRetryPolicyFailsafePlugin(final String id, final Client client) {
         if (client.getRetry().getEnabled()) {
             final String pluginId = registry.registerIfAbsent(name(id, "RetryPolicy", FailsafePlugin.class), () -> {
-                var failsafeExecutor = registry.find (name(id, "RetryPolicy", ExecutorService.class));
+                var executorService = registry.find(name(id, "RetryPolicy", ExecutorService.class));
 
                 log.debug("Client [{}]: Registering [RetryPolicyFailsafePlugin]", id);
-                if (failsafeExecutor.isPresent()) {
-                    return genericBeanDefinition(FailsafePluginFactory.class)
-                            .setFactoryMethod("createRetryFailsafePlugin")
-                            .addConstructorArgValue(client)
-                            .addConstructorArgValue(createTaskDecorators(id, client))
-                            .addConstructorArgValue(ref(failsafeExecutor.get()));
-                } else {
-                    return genericBeanDefinition(FailsafePluginFactory.class)
-                            .setFactoryMethod("createRetryFailsafePlugin")
-                            .addConstructorArgValue(client)
-                            .addConstructorArgValue(createTaskDecorators(id, client))
-                            .addConstructorArgValue(null);
-                }
-
+                return executorService.map(executorServiceBeanName -> genericBeanDefinition(FailsafePluginFactory.class)
+                                .setFactoryMethod("createRetryFailsafePlugin")
+                                .addConstructorArgValue(client)
+                                .addConstructorArgValue(createTaskDecorators(id, client))
+                                .addConstructorArgValue(ref(executorServiceBeanName)))
+                        .orElseGet(() -> genericBeanDefinition(FailsafePluginFactory.class)
+                                .setFactoryMethod("createRetryFailsafePlugin")
+                                .addConstructorArgValue(client)
+                                .addConstructorArgValue(createTaskDecorators(id, client))
+                                .addConstructorArgValue(null));
             });
             return Optional.of(pluginId);
         }
@@ -460,11 +464,18 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
         if (client.getBackupRequest().getEnabled()) {
             final String pluginId = registry.registerIfAbsent(name(id, BackupRequest.class, FailsafePlugin.class),
                     () -> {
+                        var executorService = registry.find(name(id, "BackupRequest", ExecutorService.class));
                         log.debug("Client [{}]: Registering [BackupRequestFailsafePlugin]", id);
-                        return genericBeanDefinition(FailsafePluginFactory.class)
-                                .setFactoryMethod("createBackupRequestPlugin")
-                                .addConstructorArgValue(client)
-                                .addConstructorArgValue(createTaskDecorators(id, client));
+                        return executorService.map(executorServiceBeanName -> genericBeanDefinition(FailsafePluginFactory.class)
+                                        .setFactoryMethod("createBackupRequestPlugin")
+                                        .addConstructorArgValue(client)
+                                        .addConstructorArgValue(createTaskDecorators(id, client))
+                                        .addConstructorArgValue(ref(executorServiceBeanName)))
+                                .orElseGet(() -> genericBeanDefinition(FailsafePluginFactory.class)
+                                        .setFactoryMethod("createBackupRequestPlugin")
+                                        .addConstructorArgValue(client)
+                                        .addConstructorArgValue(createTaskDecorators(id, client))
+                                        .addConstructorArgValue(null));
                     });
             return Optional.of(pluginId);
         }
@@ -474,11 +485,19 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
     private Optional<String> registerTimeoutFailsafePlugin(final String id, final Client client) {
         if (client.getTimeouts().getEnabled()) {
             final String pluginId = registry.registerIfAbsent(name(id, Timeout.class, FailsafePlugin.class), () -> {
+                var executorService = registry.find(name(id, "Timeout", ExecutorService.class));
+
                 log.debug("Client [{}]: Registering [TimeoutFailsafePlugin]", id);
-                return genericBeanDefinition(FailsafePluginFactory.class)
-                        .setFactoryMethod("createTimeoutPlugin")
-                        .addConstructorArgValue(client)
-                        .addConstructorArgValue(createTaskDecorators(id, client));
+                return executorService.map(executorServiceBeanName -> genericBeanDefinition(FailsafePluginFactory.class)
+                                .setFactoryMethod("createTimeoutPlugin")
+                                .addConstructorArgValue(client)
+                                .addConstructorArgValue(createTaskDecorators(id, client))
+                                .addConstructorArgValue(ref(executorServiceBeanName)))
+                        .orElseGet(() -> genericBeanDefinition(FailsafePluginFactory.class)
+                                .setFactoryMethod("createTimeoutPlugin")
+                                .addConstructorArgValue(client)
+                                .addConstructorArgValue(createTaskDecorators(id, client))
+                                .addConstructorArgValue(null));
             });
             return Optional.of(pluginId);
         }

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideRegistrar.java
@@ -412,10 +412,10 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
 
                         log.debug("Client [{}]: Registering [CircuitBreakerFailsafePlugin]", id);
                         return genericBeanDefinition(FailsafePluginFactory.class)
-                                        .setFactoryMethod("createCircuitBreakerPlugin")
-                                        .addConstructorArgValue(registerCircuitBreaker(id, client))
-                                        .addConstructorArgValue(createTaskDecorators(id, client))
-                                        .addConstructorArgValue(executorServiceRef);
+                                .setFactoryMethod("createCircuitBreakerPlugin")
+                                .addConstructorArgValue(registerCircuitBreaker(id, client))
+                                .addConstructorArgValue(createTaskDecorators(id, client))
+                                .addConstructorArgValue(executorServiceRef);
                     });
             return Optional.of(pluginId);
         }
@@ -430,10 +430,10 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
 
                 log.debug("Client [{}]: Registering [RetryPolicyFailsafePlugin]", id);
                 return genericBeanDefinition(FailsafePluginFactory.class)
-                                .setFactoryMethod("createRetryFailsafePlugin")
-                                .addConstructorArgValue(client)
-                                .addConstructorArgValue(createTaskDecorators(id, client))
-                                .addConstructorArgValue(executorServiceRef);
+                        .setFactoryMethod("createRetryFailsafePlugin")
+                        .addConstructorArgValue(client)
+                        .addConstructorArgValue(createTaskDecorators(id, client))
+                        .addConstructorArgValue(executorServiceRef);
             });
             return Optional.of(pluginId);
         }
@@ -461,10 +461,10 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
 
                         log.debug("Client [{}]: Registering [BackupRequestFailsafePlugin]", id);
                         return genericBeanDefinition(FailsafePluginFactory.class)
-                                        .setFactoryMethod("createBackupRequestPlugin")
-                                        .addConstructorArgValue(client)
-                                        .addConstructorArgValue(createTaskDecorators(id, client))
-                                        .addConstructorArgValue(executorServiceRef);
+                                .setFactoryMethod("createBackupRequestPlugin")
+                                .addConstructorArgValue(client)
+                                .addConstructorArgValue(createTaskDecorators(id, client))
+                                .addConstructorArgValue(executorServiceRef);
                     });
             return Optional.of(pluginId);
         }
@@ -479,10 +479,10 @@ final class DefaultRiptideRegistrar implements RiptideRegistrar {
 
                 log.debug("Client [{}]: Registering [TimeoutFailsafePlugin]", id);
                 return genericBeanDefinition(FailsafePluginFactory.class)
-                                .setFactoryMethod("createTimeoutPlugin")
-                                .addConstructorArgValue(client)
-                                .addConstructorArgValue(createTaskDecorators(id, client))
-                                .addConstructorArgValue(executorServiceRef);
+                        .setFactoryMethod("createTimeoutPlugin")
+                        .addConstructorArgValue(client)
+                        .addConstructorArgValue(createTaskDecorators(id, client))
+                        .addConstructorArgValue(executorServiceRef);
             });
             return Optional.of(pluginId);
         }

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/FailsafePluginFactory.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/FailsafePluginFactory.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -83,10 +84,13 @@ final class FailsafePluginFactory {
     }
 
     public static Plugin createRetryFailsafePlugin(
-            final Client client, final List<TaskDecorator> decorators) {
+            final Client client,
+            final List<TaskDecorator> decorators,
+            final ExecutorService executorService) {
 
         if (client.getTransientFaultDetection().getEnabled()) {
             return new FailsafePlugin()
+                    .withExecutor(executorService)
                     .withPolicy(new RetryRequestPolicy(getRetryPolicyBuilder(client)
                             .handleIf(toCheckedPredicate(transientSocketFaults()))
                             .build())

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Registry.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Registry.java
@@ -50,7 +50,7 @@ final class Registry {
         return find(name(id, types));
     }
 
-    private Optional<String> find(final Name name) {
+    Optional<String> find(final Name name) {
         return name.getAlternatives().stream()
                 .filter(registry::isBeanNameInUse)
                 .findFirst();

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeCustomExecutorTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeCustomExecutorTest.java
@@ -18,7 +18,6 @@ import org.zalando.riptide.autoconfigure.OpenTracingTestAutoConfiguration;
 import org.zalando.riptide.autoconfigure.RiptideClientTest;
 
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -28,11 +27,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.http.HttpStatus.Series.SERVER_ERROR;
 import static org.springframework.test.web.client.ExpectedCount.times;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.zalando.riptide.Bindings.anySeries;
 import static org.zalando.riptide.Bindings.on;
@@ -136,7 +133,6 @@ public class FailsafeCustomExecutorTest {
 
     @Test
     void shouldRetryForAtMostMaxRetriesTimes() {
-
         int invocationCount = 3;
         server.expect(times(invocationCount), requestTo("http://retry-test")).andRespond(withSuccess());
 

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeCustomExecutorTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeCustomExecutorTest.java
@@ -1,7 +1,6 @@
 package org.zalando.riptide.autoconfigure.retry;
 
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,6 +16,7 @@ import org.zalando.riptide.autoconfigure.MetricsTestAutoConfiguration;
 import org.zalando.riptide.autoconfigure.OpenTracingTestAutoConfiguration;
 import org.zalando.riptide.autoconfigure.RiptideClientTest;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -42,7 +42,7 @@ import static org.zalando.riptide.failsafe.RetryRoute.retry;
 @Slf4j
 public class FailsafeCustomExecutorTest {
 
-    public static class CountingExecutorService extends ThreadPoolExecutor {
+    private static class CountingExecutorService extends ThreadPoolExecutor {
         private final String name;
         AtomicInteger counter = new AtomicInteger();
 
@@ -62,7 +62,7 @@ public class FailsafeCustomExecutorTest {
         }
 
         @Override
-        public void execute(@NotNull Runnable command) {
+        public void execute(@Nonnull Runnable command) {
             super.execute(() -> {
                 log.info("Failsafe executor runnable " + name);
                 counter.incrementAndGet();

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeCustomExecutorTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeCustomExecutorTest.java
@@ -88,7 +88,7 @@ public class FailsafeCustomExecutorTest {
 
         @Bean(name = "custom-executor-testCircuitBreakerExecutorService")
         public ExecutorService circuitBreakerExecutorService() {
-            return new CountingExecutorService("circuitBreaker", 3, 3,
+            return new CountingExecutorService("circuitBreaker", 1, 1,
                     0L, TimeUnit.MILLISECONDS,
                     new LinkedBlockingQueue<>());
         }

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeCustomExecutorTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeCustomExecutorTest.java
@@ -1,0 +1,153 @@
+package org.zalando.riptide.autoconfigure.retry;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.zalando.logbook.autoconfigure.LogbookAutoConfiguration;
+import org.zalando.riptide.Http;
+import org.zalando.riptide.autoconfigure.MetricsTestAutoConfiguration;
+import org.zalando.riptide.autoconfigure.OpenTracingTestAutoConfiguration;
+import org.zalando.riptide.autoconfigure.RiptideClientTest;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.http.HttpStatus.Series.SERVER_ERROR;
+import static org.springframework.test.web.client.ExpectedCount.times;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.zalando.riptide.Bindings.anySeries;
+import static org.zalando.riptide.Bindings.on;
+import static org.zalando.riptide.Navigators.series;
+import static org.zalando.riptide.PassRoute.pass;
+import static org.zalando.riptide.failsafe.RetryRoute.retry;
+
+@RiptideClientTest
+@ActiveProfiles("default")
+@Slf4j
+public class FailsafeCustomExecutorTest {
+
+    public static class CountingExecutorService extends ThreadPoolExecutor {
+        private final String name;
+        AtomicInteger counter = new AtomicInteger();
+
+        public CountingExecutorService(String name,
+                                       int corePoolSize,
+                                       int maximumPoolSize,
+                                       long keepAliveTime,
+                                       TimeUnit unit,
+                                       BlockingQueue<Runnable> workQueue) {
+            super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue,
+                    Executors.defaultThreadFactory());
+            this.name = name;
+        }
+
+        void resetCounter() {
+            counter.set(0);
+        }
+
+        @Override
+        public void execute(@NotNull Runnable command) {
+            super.execute(() -> {
+                log.info("Failsafe executor runnable " + name);
+                counter.incrementAndGet();
+                command.run();
+            });
+        }
+    }
+
+    @Configuration
+    @ImportAutoConfiguration({
+            JacksonAutoConfiguration.class,
+            LogbookAutoConfiguration.class,
+            OpenTracingTestAutoConfiguration.class,
+            MetricsTestAutoConfiguration.class,
+    })
+    static class ContextConfiguration {
+        @Bean(name = "custom-executor-testRetryPolicyExecutorService")
+        public ExecutorService retryPolicyExecutorService() {
+            return new CountingExecutorService("retryPolicy", 3, 3,
+                    0L, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<>());
+        }
+
+        @Bean(name = "custom-executor-testCircuitBreakerExecutorService")
+        public ExecutorService circuitBreakerExecutorService() {
+            return new CountingExecutorService("circuitBreaker", 3, 3,
+                    0L, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<>());
+        }
+
+        @Bean(name = "custom-executor-testBackupRequestExecutorService")
+        public ExecutorService backupRequestExecutorService() {
+            return new CountingExecutorService("backupRequest", 3, 3,
+                    0L, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<>());
+        }
+
+        @Bean(name = "custom-executor-testTimeoutExecutorService")
+        public ExecutorService timeoutExecutorService() {
+            return new CountingExecutorService("timeout", 3, 3,
+                    0L, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<>());
+        }
+    }
+
+    @Autowired
+    @Qualifier("custom-executor-test")
+    private Http httpClient;
+
+    @Autowired
+    @Qualifier("custom-executor-testRetryPolicyExecutorService")
+    private CountingExecutorService retryPolicyExecutorService;
+
+    @Autowired
+    @Qualifier("custom-executor-testCircuitBreakerExecutorService")
+    private CountingExecutorService circuitBreakerExecutorService;
+
+    @Autowired
+    @Qualifier("custom-executor-testBackupRequestExecutorService")
+    private CountingExecutorService backupRequestExecutorService;
+
+    @Autowired
+    @Qualifier("custom-executor-testTimeoutExecutorService")
+    private CountingExecutorService timeoutExecutorService;
+
+    @Autowired
+    private MockRestServiceServer server;
+
+    @Test
+    void shouldRetryForAtMostMaxRetriesTimes() {
+
+        int invocationCount = 3;
+        server.expect(times(invocationCount), requestTo("http://retry-test")).andRespond(withSuccess());
+
+        IntStream.range(0, invocationCount).forEach(i -> httpClient.get().dispatch(series(),
+                        on(SERVER_ERROR).call(retry()), anySeries().call(pass()))
+                .join());
+
+        server.verify();
+        assertEquals(invocationCount, retryPolicyExecutorService.counter.get());
+        assertEquals(invocationCount, circuitBreakerExecutorService.counter.get());
+        assertEquals(invocationCount, backupRequestExecutorService.counter.get());
+        assertEquals(invocationCount, timeoutExecutorService.counter.get());
+    }
+}

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeRetryTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/FailsafeRetryTest.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -16,8 +15,6 @@ import org.zalando.riptide.autoconfigure.OpenTracingTestAutoConfiguration;
 import org.zalando.riptide.autoconfigure.RiptideClientTest;
 
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.http.HttpStatus.Series.SERVER_ERROR;
@@ -30,7 +27,7 @@ import static org.zalando.riptide.failsafe.RetryRoute.retry;
 
 @RiptideClientTest
 @ActiveProfiles("default")
-public class RetryTest {
+public class FailsafeRetryTest {
     @Configuration
     @ImportAutoConfiguration({
             JacksonAutoConfiguration.class,
@@ -39,10 +36,6 @@ public class RetryTest {
             MetricsTestAutoConfiguration.class,
     })
     static class ContextConfiguration {
-        @Bean(name = "retry-testRetryPolicyExecutorService")
-        public ExecutorService executorService() {
-            return Executors.newFixedThreadPool(2);
-        }
     }
 
     @Autowired

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/RetryTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/RetryTest.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -15,6 +16,8 @@ import org.zalando.riptide.autoconfigure.OpenTracingTestAutoConfiguration;
 import org.zalando.riptide.autoconfigure.RiptideClientTest;
 
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.http.HttpStatus.Series.SERVER_ERROR;
@@ -36,6 +39,10 @@ public class RetryTest {
             MetricsTestAutoConfiguration.class,
     })
     static class ContextConfiguration {
+        @Bean(name = "retry-testRetryPolicyExecutorService")
+        public ExecutorService executorService() {
+            return Executors.newFixedThreadPool(2);
+        }
     }
 
     @Autowired

--- a/riptide-spring-boot-autoconfigure/src/test/resources/application-default.yml
+++ b/riptide-spring-boot-autoconfigure/src/test/resources/application-default.yml
@@ -104,6 +104,22 @@ riptide:
       retry:
         enabled: true
         max-retries: 2
+    custom-executor-test:
+      base-url: http://retry-test
+      transient-fault-detection.enabled: true
+      retry:
+        enabled: true
+        max-retries: 2
+      circuit-breaker:
+        enabled: true
+        failure-rate-threshold: 3 in 5 seconds
+        success-threshold: 1
+      timeouts:
+        enabled: true
+        global: 5 seconds
+      backup-request:
+        enabled: true
+        delay: 75 milliseconds
     failure-rate-test:
       base-url: http://example.com/failure-rate-test
       circuit-breaker:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes allow to specify custom `ExecutorService` for the `FailsafePlugin`. If `ExecutorService` is not specified - we don't use any default value and delegate executor creation to the `Failsafe` library.
    
It is also possible to provide custom `ExecutorService` as a bean if Spring Boot starter is used. Since 4 different `FailsafePlugin`-s can be created for each `Http` client (see [FailsafePluginFactory](https://github.com/Semernitskaya/riptide/blob/f8525841c9f1cfddeb00dbabcd4cb91f191b7be0/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/FailsafePluginFactory.java#L169)) - 4 custom `ExecutorService`-s can be specified (naming convention is provided in Spring Boot starter [documentation](https://github.com/zalando/riptide/pull/1503/files#diff-cac26b0853dfe7f7df5898467d9a7d21fe3c0d656f8debcaedab57f4c6d20f39)). If no custom `ExecutorService` is provided - `ExecutorService` creation again will be delegated to the the `Failsafe` library, no `ExecutorService` beans will be created.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/zalando/riptide/issues/1501

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
