### PR TITLE
Fixing ConnectException name

### DIFF
--- a/riptide-faults/README.md
+++ b/riptide-faults/README.md
@@ -56,7 +56,7 @@ new RetryRequestPolicy(
 ```
 
 The default considers the following exceptions to be transient connection faults:
-- [`ConnectionException`](https://docs.oracle.com/javase/8/docs/api/java/net/ConnectionException.html)
+- [`ConnectException`](https://docs.oracle.com/javase/8/docs/api/java/net/ConnectException.html)
 - [`MalformedURLException`](https://docs.oracle.com/javase/8/docs/api/java/net/MalformedURLException.html)
 - [`NoRouteToHostException`](https://docs.oracle.com/javase/8/docs/api/java/net/NoRouteToHostException.html)
 - [`UnknownHostException`](https://docs.oracle.com/javase/8/docs/api/java/net/UnknownHostException.html)


### PR DESCRIPTION
## Description
This PR fixes the docs by using the correct name for the JRE [ConnectException](https://docs.oracle.com/javase/8/docs/api/java/net/ConnectException.html) class. See also [this usage](https://github.com/zalando/riptide/blob/5f004a2e3ad920c87ae393a13157c31363c1ebd3/riptide-faults/src/main/java/org/zalando/riptide/faults/TransientFaults.java#L76) in the source code.