### PR TITLE
fix documentation for providing custom bean scenario

### DIFF
--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -575,15 +575,24 @@ For every client that is defined in your configuration the following beans will 
 [![Client Dependency Graph](../docs/interceptors.png)](../docs/interceptors.png)
 
 Every single bean in the graph can optionally be replaced by your own, custom version of it. Beans can only be
-overridden by name, **not** by type. As an example, the following code would add XML support to the `example` client:
+overridden by name, **not** by type. You can define bean name by using an appropriate method name or specify it explicitly via `@Bean(name = "...")`,
+you cannot use `@Qualifier("...")` annotation since it doesn't change an actual bean name.
+As an example, the following code would add XML support to the `example` client:
 
 ```java
 @Bean
-@Qualifier("example")
 public ClientHttpMessageConverters exampleHttpMessageConverters() {
     return new ClientHttpMessageConverters(singletonList(new Jaxb2RootElementHttpMessageConverter()));
 }
 ```
+
+The following code can be used if cannot use your client name in the method name (e.g. your client name is `my-client`):
+@Bean(name = "my-clientCircuitBreakerExecutorService")
+public ClientHttpMessageConverters httpMessageConverters() {
+    return new ClientHttpMessageConverters(singletonList(new Jaxb2RootElementHttpMessageConverter()));
+}
+```
+As you can see, any method name can be used in the second case.
 
 The following table shows all beans with their respective name (for the `example` client) and type:
 


### PR DESCRIPTION
## Description
Fixed documentation for bean overriding process

## Motivation and Context
I found that bean overriding description is not fully clear and can confuse Riptide users, especially challenging can be cases when Http client bean name can't be used as-is in the method name. I provided more detailed description and one additional  example.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
