### PR TITLE
(refactor) make RetryException constructor public

### DIFF
--- a/riptide-failsafe/README.md
+++ b/riptide-failsafe/README.md
@@ -77,6 +77,23 @@ RetryPolicy.<ClientHttpResponse>builder()
     .build();
 ```
 
+By default, you can use RetryException in your routes to retry the request:
+
+```java
+retryClient.get()
+    .dispatch(
+        series(), on(CLIENT_ERROR).call(
+            response -> {
+                if (specificCondition(response)) {
+                    throw new RetryException(response); // we will retry this one
+                }  else {
+                    throw new AnyOtherException(response); // we wont retry this one
+                }  
+            }
+        )
+    ).join()
+```
+
 Failsafe supports dynamically computed delays using a custom function.
 
 Riptide: Failsafe offers implementations that understand:

--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/RetryException.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/RetryException.java
@@ -11,7 +11,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 @API(status = STABLE)
 public final class RetryException extends HttpResponseException {
 
-    RetryException(final ClientHttpResponse response) throws IOException {
+    public RetryException(final ClientHttpResponse response) throws IOException {
         super("Retrying response", response);
     }
 


### PR DESCRIPTION
Make `RetryException` constructor public to allow using it in the code for easily retry whenever it's needed. 

## Description
The RetryException which is used for default Failsafe retry handling is now package private which prevents the users from easily introduce retries into their code which have specific cases.

## Motivation and Context
Use case: i want to be able to retry specific `400` responses but not all of them, right now i have to define my own failsafe plugin or do some extra steps vs. just importing the `RetryException` and use it where i see fit.

Example on Kotlin:
```kotlin
 on(HttpStatus.Series.CLIENT_ERROR).dispatch(
              Navigators.status(),
              on(HttpStatus.BAD_REQUEST).call(Problem::class.java) { exception ->
                if (someConditionForBadRequestException
                ) {
                  throw RetryException(exception)
                } else {
                  ...
                }
              },
              anyStatus().call(ProblemRoute.problemHandling())
            )
          )
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
