### PR TITLE
Fix X-RateLimit headers handling when using CompositeDelayFunction

### DIFF
--- a/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/CompositeDelayFunction.java
+++ b/riptide-failsafe/src/main/java/org/zalando/riptide/failsafe/CompositeDelayFunction.java
@@ -29,8 +29,9 @@ public final class CompositeDelayFunction<R> implements ContextualSupplier<R, Du
                     }
                 })
                 .filter(Objects::nonNull)
+                .filter(delay -> !Duration.ofMinutes(-1).equals(delay))
                 .findFirst()
-                .orElse(null);
+                .orElse(Duration.ofMinutes(-1));
     }
 
     @SafeVarargs

--- a/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/CompositeDelayFunctionTest.java
+++ b/riptide-failsafe/src/test/java/org/zalando/riptide/failsafe/CompositeDelayFunctionTest.java
@@ -11,7 +11,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,8 +42,8 @@ final class CompositeDelayFunctionTest {
     @BeforeEach
     void defaultBehavior() throws Throwable {
         // starting with Mockito 3.4.4, mocks will return Duration.ZERO instead of null, by default
-        when(first.get(any())).thenReturn(null);
-        when(first.get(any())).thenReturn(null);
+        when(first.get(any())).thenReturn(Duration.ofMinutes(-1));
+        when(first.get(any())).thenReturn(Duration.ofMinutes(-1));
     }
 
     @Test
@@ -73,11 +72,18 @@ final class CompositeDelayFunctionTest {
     }
 
     @Test
-    void shouldFallbackToNullDelay() throws Throwable {
+    void shouldFallbackToDefaultDelay() throws Throwable {
         when(first.get(eq(firstContext))).thenReturn(Duration.ofSeconds(1));
         when(second.get(eq(secondContext))).thenReturn(Duration.ofSeconds(2));
 
-        assertNull(unit.get(mock(ExecutionContext.class)));
+        assertEquals(Duration.ofMinutes(-1), unit.get(mock(ExecutionContext.class)));
+    }
+
+    @Test
+    void shouldUseFirstNonDefaultDelay() throws Throwable {
+        when(second.get(eq(secondContext))).thenReturn(Duration.ofSeconds(2));
+
+        assertEquals(Duration.ofSeconds(2), unit.get(secondContext));
     }
 
 }

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/XRateLimitResetRetryTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/retry/XRateLimitResetRetryTest.java
@@ -1,0 +1,77 @@
+package org.zalando.riptide.autoconfigure.retry;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.http.HttpStatus.Series.SUCCESSFUL;
+import static org.springframework.test.web.client.ExpectedCount.times;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withRawStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.zalando.riptide.Bindings.anySeries;
+import static org.zalando.riptide.Bindings.on;
+import static org.zalando.riptide.Navigators.series;
+import static org.zalando.riptide.Navigators.status;
+import static org.zalando.riptide.PassRoute.pass;
+import static org.zalando.riptide.failsafe.RetryRoute.retry;
+
+import com.google.common.base.Stopwatch;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.zalando.logbook.autoconfigure.LogbookAutoConfiguration;
+import org.zalando.riptide.Http;
+import org.zalando.riptide.autoconfigure.MetricsTestAutoConfiguration;
+import org.zalando.riptide.autoconfigure.OpenTracingTestAutoConfiguration;
+import org.zalando.riptide.autoconfigure.RiptideClientTest;
+
+@RiptideClientTest
+@ActiveProfiles("default")
+public class XRateLimitResetRetryTest {
+  @Configuration
+  @ImportAutoConfiguration({
+      JacksonAutoConfiguration.class,
+      LogbookAutoConfiguration.class,
+      OpenTracingTestAutoConfiguration.class,
+      MetricsTestAutoConfiguration.class,
+  })
+  static class ContextConfiguration {
+  }
+
+  @Autowired
+  @Qualifier("retry-test")
+  private Http retryClient;
+
+  @Autowired
+  private MockRestServiceServer server;
+
+  @Test
+  void shouldObeyXRateLimitHeader() {
+    server.expect(times(1), requestTo("http://retry-test"))
+        .andRespond(withRawStatus(429).headers(new HttpHeaders() {{
+          add("X-RateLimit-Limit", "1");
+          add("X-RateLimit-Remaining", "0");
+          add("X-RateLimit-Reset", "2");
+        }}));
+    server.expect(times(1), requestTo("http://retry-test")).andRespond(withSuccess());
+
+    final Stopwatch stopwatch = Stopwatch.createStarted();
+    retryClient.get()
+        .dispatch(series(),
+            on(SUCCESSFUL).call(pass()),
+            anySeries().dispatch(status(),
+                on(HttpStatus.TOO_MANY_REQUESTS).call(retry())))
+        .join();
+    Duration elapsed = stopwatch.stop().elapsed();
+
+    assertThat(elapsed, greaterThanOrEqualTo(Duration.ofSeconds(2)));
+    server.verify();
+  }
+}


### PR DESCRIPTION
1. Filtering out default durations in the CompositeDelayFunction.
2. Returning default duration from the CompositeDelayFunction instead of null.

## Description
Since RateLimitResetDelayFunction and RetryAfterDelayFunction are returning `Duration.ofMinutes(-1)` instead of null as the default value since Riptide 4, it is needed to check not only for non-null values but also if there are any non-default delays in the CompositeDelayFunction.

## Motivation and Context
1. In Riptide 4 the default value in RateLimitResetDelayFunction and RetryAfterDelayFunction was changed from null to `Duration.ofMinutes(-1)` [link](https://github.com/zalando/riptide/commit/6bf111c9dec8c8d23e501e19d0bac2838917d142)
2. Failsafe 2.x.x used both negative duration and null as default values ([link](https://javadoc.io/static/net.jodah/failsafe/2.4.4/index.html?net/jodah/failsafe/function/DelayFunction.html)) 
3. Failsafe 3.x.x mentions only negative values as default values [(link)](https://failsafe.dev/javadoc/core/dev/failsafe/DelayablePolicyBuilder.html#withDelayFn-dev.failsafe.function.ContextualSupplier-). If null is returned from delay function, it leads to NPE in the Failsafe.

As Riptide 4, if CompositeDelayFunction consists of two functions (A and B) and A returns default value and B returns a positive meaningful value, the default value would be taken since it is not null.
 
The issue is opened [here](https://github.com/zalando/riptide/issues/1671).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
