### PR TITLE
Make it possible to use spring-boots ssl-bundle support

### DIFF
--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideConfigurer.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/DefaultRiptideConfigurer.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.config.BeanReference;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.config.ConstructorArgumentValues.ValueHolder;
+import org.springframework.boot.ssl.SslBundles;
 import org.zalando.logbook.Logbook;
 
 import java.util.Arrays;
@@ -22,6 +23,7 @@ import java.util.function.Predicate;
 
 import static org.zalando.riptide.autoconfigure.ValueConstants.LOGBOOK_REF;
 import static org.zalando.riptide.autoconfigure.ValueConstants.METER_REGISTRY_REF;
+import static org.zalando.riptide.autoconfigure.ValueConstants.SSL_BUNDLE_REGISTRY_REF;
 import static org.zalando.riptide.autoconfigure.ValueConstants.TRACER_REF;
 
 @AllArgsConstructor
@@ -54,6 +56,10 @@ class DefaultRiptideConfigurer {
 
         if (any(client -> client.getMetrics().getEnabled())) {
             replacements.put(METER_REGISTRY_REF, getBeanRef(MeterRegistry.class, "meterRegistry"));
+        }
+
+        if (any(client -> client.getSslBundleUsage().getEnabled())) {
+            replacements.put(SSL_BUNDLE_REGISTRY_REF, getBeanRef(SslBundles.class, "sslBundleRegistry"));
         }
 
         return replacements;

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Defaulting.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Defaulting.java
@@ -18,6 +18,7 @@ import org.zalando.riptide.autoconfigure.RiptideProperties.Metrics;
 import org.zalando.riptide.autoconfigure.RiptideProperties.RequestCompression;
 import org.zalando.riptide.autoconfigure.RiptideProperties.Retry.Backoff;
 import org.zalando.riptide.autoconfigure.RiptideProperties.Soap;
+import org.zalando.riptide.autoconfigure.RiptideProperties.SslBundleUsage;
 import org.zalando.riptide.autoconfigure.RiptideProperties.StackTracePreservation;
 import org.zalando.riptide.autoconfigure.RiptideProperties.Telemetry;
 import org.zalando.riptide.autoconfigure.RiptideProperties.Timeouts;
@@ -79,7 +80,8 @@ final class Defaulting {
                 defaults.getTracing(),
                 defaults.getTelemetry(),
                 defaults.getChaos(),
-                defaults.getSoap()
+                defaults.getSoap(),
+                defaults.getSslBundleUsage()
         );
     }
 
@@ -121,7 +123,8 @@ final class Defaulting {
                 merge(base.getTracing(), defaults.getTracing(), Defaulting::merge),
                 merge(base.getTelemetry(), defaults.getTelemetry(), Defaulting::merge),
                 merge(base.getChaos(), defaults.getChaos(), Defaulting::merge),
-                merge(base.getSoap(), defaults.getSoap(), Defaulting::merge)
+                merge(base.getSoap(), defaults.getSoap(), Defaulting::merge),
+                merge(base.getSslBundleUsage(), defaults.getSslBundleUsage(), Defaulting::merge)
         );
     }
 
@@ -339,6 +342,13 @@ final class Defaulting {
         return new Soap(
                 either(base.getEnabled(), defaults.getEnabled()),
                 either(base.getProtocol(), defaults.getProtocol())
+        );
+    }
+
+    private static SslBundleUsage merge(final SslBundleUsage base, final SslBundleUsage defaults) {
+        return new SslBundleUsage(
+            either(base.getEnabled(), defaults.getEnabled()),
+            either(base.getSslBundleId(), defaults.getSslBundleId())
         );
     }
 

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/RiptideProperties.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/RiptideProperties.java
@@ -144,6 +144,9 @@ public final class RiptideProperties {
         @NestedConfigurationProperty
         private Soap soap = new Soap(false, "1.1");
 
+        @NestedConfigurationProperty
+        private SslBundleUsage sslBundleUsage = new SslBundleUsage(false, null);
+
     }
 
     @Getter
@@ -213,6 +216,9 @@ public final class RiptideProperties {
 
         @NestedConfigurationProperty
         private Soap soap;
+
+        @NestedConfigurationProperty
+        private SslBundleUsage sslBundleUsage;
 
     }
 
@@ -458,6 +464,15 @@ public final class RiptideProperties {
     public static final class Soap {
         private Boolean enabled;
         private String protocol;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static final class SslBundleUsage {
+        private Boolean enabled;
+        private String sslBundleId;
     }
 
 }

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/SslBundleUsageOrCertificatePinningException.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/SslBundleUsageOrCertificatePinningException.java
@@ -1,0 +1,31 @@
+package org.zalando.riptide.autoconfigure;
+
+import org.springframework.core.NestedRuntimeException;
+
+public class SslBundleUsageOrCertificatePinningException extends NestedRuntimeException {
+
+  private final String clientId;
+
+  public SslBundleUsageOrCertificatePinningException(final String clientId) {
+    super(createMessage(clientId));
+    this.clientId = clientId;
+  }
+
+  public SslBundleUsageOrCertificatePinningException(String clientId, String msg) {
+    super(msg);
+    this.clientId = clientId;
+  }
+
+  public SslBundleUsageOrCertificatePinningException(String clientId, String msg, Throwable cause) {
+    super(msg, cause);
+    this.clientId = clientId;
+  }
+
+  protected static String createMessage(String clientId) {
+    return String.format("CertificatePinning and SslBundleUsage configured at same time in http-client : '%s'", clientId);
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+}

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/SslBundleUsageOrCertificatePinningFailureAnalyzer.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/SslBundleUsageOrCertificatePinningFailureAnalyzer.java
@@ -1,0 +1,22 @@
+package org.zalando.riptide.autoconfigure;
+
+import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+
+public class SslBundleUsageOrCertificatePinningFailureAnalyzer extends
+    AbstractFailureAnalyzer<SslBundleUsageOrCertificatePinningException> {
+
+  @Override
+  protected FailureAnalysis analyze(Throwable rootFailure,
+      SslBundleUsageOrCertificatePinningException cause) {
+    return new FailureAnalysis(getDescription(cause), getAction(cause), cause);
+  }
+
+  private String getDescription(SslBundleUsageOrCertificatePinningException cause) {
+    return String.format("The http-client '%s' is configured to use CertificatePinning and SslBundleUsage at the same time.", cause.getClientId());
+  }
+
+  private String getAction(SslBundleUsageOrCertificatePinningException cause) {
+    return String.format("Configure only CertificatePinning or SslBundleUsage for http-client '%s'", cause.getClientId());
+  }
+}

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/ValueConstants.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/ValueConstants.java
@@ -14,5 +14,6 @@ class ValueConstants {
     static final String METER_REGISTRY_REF = "\n\t\t\n\t\t\n\uE000\uE001\uE001\n\t\t\t\t\n";
     static final String TRACER_REF = "\n\t\t\n\t\t\n\uE000\uE001\uE002\n\t\t\t\t\n";
     static final String LOGBOOK_REF = "\n\t\t\n\t\t\n\uE000\uE001\uE003\n\t\t\t\t\n";
+    static final String SSL_BUNDLE_REGISTRY_REF = "\n\t\t\n\uE000\uE001\uE004\n\t\t\t\t\n";
 
 }

--- a/riptide-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/riptide-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.diagnostics.FailureAnalyzer=\
+  org.zalando.riptide.autoconfigure.SslBundleUsageOrCertificatePinningFailureAnalyzer

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/HttpClientFactorySslBundleTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/HttpClientFactorySslBundleTest.java
@@ -1,0 +1,134 @@
+package org.zalando.riptide.autoconfigure;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.zalando.riptide.autoconfigure.HttpClientFactory.createHttpClientConnectionManagerWithSslBundle;
+import static org.zalando.riptide.autoconfigure.HttpClientFactory.createSslContextFromSslBundle;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.net.ssl.SSLContext;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
+import org.springframework.boot.ssl.DefaultSslBundleRegistry;
+import org.springframework.boot.ssl.NoSuchSslBundleException;
+import org.springframework.boot.ssl.SslBundle;
+import org.zalando.riptide.autoconfigure.RiptideProperties.CertificatePinning;
+import org.zalando.riptide.autoconfigure.RiptideProperties.Defaults;
+import org.zalando.riptide.autoconfigure.RiptideProperties.SslBundleUsage;
+import org.zalando.riptide.autoconfigure.RiptideProperties.Threads;
+
+public class HttpClientFactorySslBundleTest {
+
+  @Test
+  void shouldFailWithoutSslBundle() {
+    final RiptideProperties.Client client = new RiptideProperties.Client();
+    client.setSslBundleUsage(new SslBundleUsage(true, null));
+
+    final NoSuchSslBundleException exception = assertThrows(
+        NoSuchSslBundleException.class,
+        () -> createHttpClientConnectionManagerWithSslBundle(
+            withDefaults(client), "example", new DefaultSslBundleRegistry()
+        )
+    );
+
+    assertThat(exception.getMessage(), containsString("'example'"));
+  }
+
+  @Test
+  void shouldFailWithSslBundle() {
+    final RiptideProperties.Client client = new RiptideProperties.Client();
+    client.setSslBundleUsage(new SslBundleUsage(true, "configured-bundle-id"));
+
+    final NoSuchSslBundleException exception = assertThrows(
+        NoSuchSslBundleException.class,
+        () -> createHttpClientConnectionManagerWithSslBundle(
+            withDefaults(client), "example", new DefaultSslBundleRegistry()
+        )
+    );
+
+    assertThat(exception.getMessage(), containsString("'configured-bundle-id'"));
+  }
+
+  @Test
+  void shouldCreateMockedSslContext() {
+    SslBundle sslBundle = Mockito.mock(SslBundle.class);
+    Mockito.when(sslBundle.createSslContext()).thenReturn(Mockito.mock(SSLContext.class));
+    final RiptideProperties.Client client = new RiptideProperties.Client();
+    client.setSslBundleUsage(new SslBundleUsage(true, "configured-bundle-id"));
+
+    DefaultSslBundleRegistry registry = new DefaultSslBundleRegistry();
+    registry.registerBundle("configured-bundle-id", sslBundle);
+
+    SSLContext result = createSslContextFromSslBundle(withDefaults(client), "example",
+        registry);
+
+    assertNotNull(result);
+    verify(sslBundle, Mockito.times(1)).createSslContext();
+  }
+
+  @Test
+  void shouldCreateDefaultSslContext() {
+    final RiptideProperties.Client client = new RiptideProperties.Client();
+    client.setSslBundleUsage(new SslBundleUsage(false, null));
+
+    SSLContext result = createSslContextFromSslBundle(
+        withDefaults(client), "example", new DefaultSslBundleRegistry()
+    );
+
+    assertNotNull(result);
+  }
+
+  @Test
+  void shouldCreateConnectionManagerWithDefaultSslContext() {
+    final RiptideProperties.Client client = new RiptideProperties.Client();
+    client.setSslBundleUsage(new SslBundleUsage(false, null));
+
+    DefaultSslBundleRegistry registry = new DefaultSslBundleRegistry();
+
+    HttpClientConnectionManager result = createHttpClientConnectionManagerWithSslBundle(
+        withDefaults(client), "example",registry
+    );
+
+    assertNotNull(result);
+  }
+
+  @Test
+  void shouldFailWhenCertificatePinningAndSslBundleUsageAreConfigured() {
+    final RiptideProperties props = new RiptideProperties();
+    final RiptideProperties.Client client = new RiptideProperties.Client();
+
+    client.setThreads(new Threads(false, 0,0, null, 0));
+    client.setSslBundleUsage(new SslBundleUsage(true, null));
+    client.setCertificatePinning(new CertificatePinning(true, null));
+
+    props.setClients(Map.of("ssl-bundle-test", client));
+
+    DefaultRiptideRegistrar registrar = new DefaultRiptideRegistrar(
+        new Registry(new SimpleBeanDefinitionRegistry()), props
+    );
+
+    final SslBundleUsageOrCertificatePinningException ex = assertThrows(
+        SslBundleUsageOrCertificatePinningException.class, () -> registrar.register()
+    );
+
+    assertEquals(
+        ex.getMessage(),
+        "CertificatePinning and SslBundleUsage configured at same time in http-client : 'ssl-bundle-test'"
+    );
+  }
+
+  private RiptideProperties.Client withDefaults(final RiptideProperties.Client client) {
+    final RiptideProperties properties = Defaulting.withDefaults(
+        new RiptideProperties(new Defaults(), ImmutableMap.of("example", client)));
+
+    return properties.getClients().get("example");
+  }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/SslBundleTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/SslBundleTest.java
@@ -1,0 +1,27 @@
+package org.zalando.riptide.autoconfigure;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.zalando.riptide.Http;
+
+@SpringBootTest(classes = {SslBundleTestConfiguration.class})
+@ActiveProfiles("ssl-bundle")
+public class SslBundleTest {
+
+  @Autowired
+  @Qualifier("ssl-bundle-test")
+  private Http sslBundleHttp;
+
+  @Test
+  void shouldAutowireHttp() {
+    assertThat(sslBundleHttp, is(notNullValue()));
+  }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/SslBundleTestConfiguration.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/SslBundleTestConfiguration.java
@@ -1,0 +1,20 @@
+package org.zalando.riptide.autoconfigure;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.zalando.logbook.autoconfigure.LogbookAutoConfiguration;
+
+@Configuration
+@ImportAutoConfiguration({
+    SslAutoConfiguration.class,
+    RiptideAutoConfiguration.class,
+    JacksonAutoConfiguration.class,
+    LogbookAutoConfiguration.class,
+    OpenTracingTestAutoConfiguration.class,
+    OpenTracingFlowIdAutoConfiguration.class,
+    MetricsTestAutoConfiguration.class,
+})
+public class SslBundleTestConfiguration {
+}

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/SslBundleUsageOrCertificatePinningExceptionTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/SslBundleUsageOrCertificatePinningExceptionTest.java
@@ -1,0 +1,34 @@
+package org.zalando.riptide.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+
+public class SslBundleUsageOrCertificatePinningExceptionTest {
+
+  @Test
+  void initialize() {
+    SslBundleUsageOrCertificatePinningException ex = new SslBundleUsageOrCertificatePinningException("test-client-id");
+    assertEquals("test-client-id", ex.getClientId());
+  }
+
+  @Test
+  void makeJacocoHappy() {
+    SslBundleUsageOrCertificatePinningException ex = new SslBundleUsageOrCertificatePinningException("test-client-id", "test message");
+    assertEquals("test message", ex.getMessage());
+    RuntimeException re = new RuntimeException();
+    ex = new SslBundleUsageOrCertificatePinningException("test-client-id", "test message", re);
+    assertEquals("test message", ex.getMessage());
+    assertEquals(re, ex.getCause());
+  }
+
+  @Test
+  void checkFailureAnalyzerMessages() {
+    SslBundleUsageOrCertificatePinningFailureAnalyzer a = new SslBundleUsageOrCertificatePinningFailureAnalyzer();
+    FailureAnalysis analysis = a.analyze(null, new SslBundleUsageOrCertificatePinningException("test-client-id"));
+    assertEquals(analysis.getDescription(), "The http-client 'test-client-id' is configured to use CertificatePinning and SslBundleUsage at the same time.");
+    assertEquals(analysis.getAction(), "Configure only CertificatePinning or SslBundleUsage for http-client 'test-client-id'");
+  }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/test/resources/application-ssl-bundle.yml
+++ b/riptide-spring-boot-autoconfigure/src/test/resources/application-ssl-bundle.yml
@@ -1,0 +1,56 @@
+riptide:
+  clients:
+    ssl-bundle-test:
+      base-url: http://example.com/ssl-bundle-test
+      ssl-bundle-usage:
+        enabled: true
+
+spring:
+  ssl:
+    bundle:
+      pem:
+        ssl-bundle-test:
+          truststore:
+            certificate: |
+              -----BEGIN CERTIFICATE-----
+              MIIHbjCCBlagAwIBAgIQB1vO8waJyK3fE+Ua9K/hhzANBgkqhkiG9w0BAQsFADBZ
+              MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMTMwMQYDVQQDEypE
+              aWdpQ2VydCBHbG9iYWwgRzIgVExTIFJTQSBTSEEyNTYgMjAyMCBDQTEwHhcNMjQw
+              MTMwMDAwMDAwWhcNMjUwMzAxMjM1OTU5WjCBljELMAkGA1UEBhMCVVMxEzARBgNV
+              BAgTCkNhbGlmb3JuaWExFDASBgNVBAcTC0xvcyBBbmdlbGVzMUIwQAYDVQQKDDlJ
+              bnRlcm5ldMKgQ29ycG9yYXRpb27CoGZvcsKgQXNzaWduZWTCoE5hbWVzwqBhbmTC
+              oE51bWJlcnMxGDAWBgNVBAMTD3d3dy5leGFtcGxlLm9yZzCCASIwDQYJKoZIhvcN
+              AQEBBQADggEPADCCAQoCggEBAIaFD7sO+cpf2fXgCjIsM9mqDgcpqC8IrXi9wga/
+              9y0rpqcnPVOmTMNLsid3INbBVEm4CNr5cKlh9rJJnWlX2vttJDRyLkfwBD+dsVvi
+              vGYxWTLmqX6/1LDUZPVrynv/cltemtg/1Aay88jcj2ZaRoRmqBgVeacIzgU8+zmJ
+              7236TnFSe7fkoKSclsBhPaQKcE3Djs1uszJs8sdECQTdoFX9I6UgeLKFXtg7rRf/
+              hcW5dI0zubhXbrW8aWXbCzySVZn0c7RkJMpnTCiZzNxnPXnHFpwr5quqqjVyN/aB
+              KkjoP04Zmr+eRqoyk/+lslq0sS8eaYSSHbC5ja/yMWyVhvMCAwEAAaOCA/IwggPu
+              MB8GA1UdIwQYMBaAFHSFgMBmx9833s+9KTeqAx2+7c0XMB0GA1UdDgQWBBRM/tAS
+              TS4hz2v68vK4TEkCHTGRijCBgQYDVR0RBHoweIIPd3d3LmV4YW1wbGUub3Jnggtl
+              eGFtcGxlLm5ldIILZXhhbXBsZS5lZHWCC2V4YW1wbGUuY29tggtleGFtcGxlLm9y
+              Z4IPd3d3LmV4YW1wbGUuY29tgg93d3cuZXhhbXBsZS5lZHWCD3d3dy5leGFtcGxl
+              Lm5ldDA+BgNVHSAENzA1MDMGBmeBDAECAjApMCcGCCsGAQUFBwIBFhtodHRwOi8v
+              d3d3LmRpZ2ljZXJ0LmNvbS9DUFMwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQG
+              CCsGAQUFBwMBBggrBgEFBQcDAjCBnwYDVR0fBIGXMIGUMEigRqBEhkJodHRwOi8v
+              Y3JsMy5kaWdpY2VydC5jb20vRGlnaUNlcnRHbG9iYWxHMlRMU1JTQVNIQTI1NjIw
+              MjBDQTEtMS5jcmwwSKBGoESGQmh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9EaWdp
+              Q2VydEdsb2JhbEcyVExTUlNBU0hBMjU2MjAyMENBMS0xLmNybDCBhwYIKwYBBQUH
+              AQEEezB5MCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wUQYI
+              KwYBBQUHMAKGRWh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEds
+              b2JhbEcyVExTUlNBU0hBMjU2MjAyMENBMS0xLmNydDAMBgNVHRMBAf8EAjAAMIIB
+              fQYKKwYBBAHWeQIEAgSCAW0EggFpAWcAdABOdaMnXJoQwzhbbNTfP1LrHfDgjhuN
+              acCx+mSxYpo53wAAAY1b0vxkAAAEAwBFMEMCH0BRCgxPbBBVxhcWZ26a8JCe83P1
+              JZ6wmv56GsVcyMACIDgpMbEo5HJITTRPnoyT4mG8cLrWjEvhchUdEcWUuk1TAHYA
+              fVkeEuF4KnscYWd8Xv340IdcFKBOlZ65Ay/ZDowuebgAAAGNW9L8MAAABAMARzBF
+              AiBdv5Z3pZFbfgoM3tGpCTM3ZxBMQsxBRSdTS6d8d2NAcwIhALLoCT9mTMN9OyFz
+              IBV5MkXVLyuTf2OAzAOa7d8x2H6XAHcA5tIxY0B3jMEQQQbXcbnOwdJA9paEhvu6
+              hzId/R43jlAAAAGNW9L8XwAABAMASDBGAiEA4Koh/VizdQU1tjZ2E2VGgWSXXkwn
+              QmiYhmAeKcVLHeACIQD7JIGFsdGol7kss2pe4lYrCgPVc+iGZkuqnj26hqhr0TAN
+              BgkqhkiG9w0BAQsFAAOCAQEABOFuAj4N4yNG9OOWNQWTNSICC4Rd4nOG1HRP/Bsn
+              rz7KrcPORtb6D+Jx+Q0amhO31QhIvVBYs14gY4Ypyj7MzHgm4VmPXcqLvEkxb2G9
+              Qv9hYuEiNSQmm1fr5QAN/0AzbEbCM3cImLJ69kP5bUjfv/76KB57is8tYf9sh5ik
+              LGKauxCM/zRIcGa3bXLDafk5S2g5Vr2hs230d/NGW1wZrE+zdGuMxfGJzJP+DAFv
+              iBfcQnFg4+1zMEKcqS87oniOyG+60RMM0MdejBD7AS43m9us96Gsun/4kufLQUTI
+              FfnzxLutUV++3seshgefQOy5C/ayi8y1VTNmujPCxPCi6Q==
+              -----END CERTIFICATE-----


### PR DESCRIPTION
This PR makes it possible to use spring-boots mechanism configuring SSL certificates/truststore/keystore with Riptide.

## Description
In Spring-Boot 3.1 a [new feature was introduced to secure applications with SSL](https://spring.io/blog/2023/06/07/securing-spring-boot-applications-with-ssl).
That was further [enhanced in Spring-Boot 3.2](https://spring.io/blog/2023/11/07/ssl-hot-reload-in-spring-boot-3-2-0).

## Motivation and Context
With a defined Spring-Boot way for configuring certificates/keystores/truststores it would make sense to support an option to use that [well-documented feature](https://docs.spring.io/spring-boot/reference/features/ssl.html) together with Riptide.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
