### PR TITLE
Update Spring to 6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <spring.version>6.1.14</spring.version>
+        <spring.version>6.2.1</spring.version>
     </properties>
 
     <build>

--- a/riptide-compatibility/src/main/java/org/zalando/riptide/compatibility/HttpOutputMessageClientHttpRequestAdapter.java
+++ b/riptide-compatibility/src/main/java/org/zalando/riptide/compatibility/HttpOutputMessageClientHttpRequestAdapter.java
@@ -9,6 +9,7 @@ import org.springframework.http.client.ClientHttpResponse;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
+import java.util.Map;
 
 @AllArgsConstructor
 final class HttpOutputMessageClientHttpRequestAdapter implements ClientHttpRequest {
@@ -22,6 +23,7 @@ final class HttpOutputMessageClientHttpRequestAdapter implements ClientHttpReque
         throw new UnsupportedOperationException();
     }
 
+    @Nonnull
     @Override
     public HttpMethod getMethod() {
         throw new UnsupportedOperationException();
@@ -33,4 +35,9 @@ final class HttpOutputMessageClientHttpRequestAdapter implements ClientHttpReque
         throw new UnsupportedOperationException();
     }
 
+    @Nonnull
+    @Override
+    public Map<String, Object> getAttributes() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/riptide-compatibility/src/test/java/org/zalando/riptide/compatibility/HttpOutputMessageClientHttpRequestAdapterTest.java
+++ b/riptide-compatibility/src/test/java/org/zalando/riptide/compatibility/HttpOutputMessageClientHttpRequestAdapterTest.java
@@ -29,4 +29,10 @@ class HttpOutputMessageClientHttpRequestAdapterTest {
         assertThrows(UnsupportedOperationException.class, unit::getURI);
     }
 
+    @Test
+    void getAttributes() {
+        assertThrows(UnsupportedOperationException.class, unit::getAttributes);
+    }
+
+
 }

--- a/riptide-httpclient/src/main/java/org/zalando/riptide/httpclient/ApacheClientHttpResponse.java
+++ b/riptide-httpclient/src/main/java/org/zalando/riptide/httpclient/ApacheClientHttpResponse.java
@@ -6,7 +6,8 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpEntityContainer;
 import org.apache.hc.core5.http.HttpResponse;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.client.AbstractClientHttpResponse;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -17,7 +18,7 @@ import static org.zalando.riptide.httpclient.Closing.closeQuietly;
 import static org.zalando.riptide.httpclient.EmptyInputStream.EMPTY;
 
 @Slf4j
-final class ApacheClientHttpResponse extends AbstractClientHttpResponse {
+final class ApacheClientHttpResponse implements ClientHttpResponse {
 
     private final HttpHeaders headers = new HttpHeaders();
     private final HttpResponse response;
@@ -48,9 +49,10 @@ final class ApacheClientHttpResponse extends AbstractClientHttpResponse {
         });
     }
 
+    @Nonnull
     @Override
-    public int getRawStatusCode() {
-        return response.getCode();
+    public HttpStatusCode getStatusCode() {
+        return HttpStatusCode.valueOf(response.getCode());
     }
 
     @Nonnull

--- a/riptide-httpclient/src/main/java/org/zalando/riptide/httpclient/BufferingApacheClientHttpRequest.java
+++ b/riptide-httpclient/src/main/java/org/zalando/riptide/httpclient/BufferingApacheClientHttpRequest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.Optional;
 
 @AllArgsConstructor
@@ -44,6 +45,12 @@ final class BufferingApacheClientHttpRequest implements ClientHttpRequest {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    @Nonnull
+    @Override
+    public Map<String, Object> getAttributes() {
+        throw new UnsupportedOperationException();
     }
 
     @Nonnull

--- a/riptide-httpclient/src/main/java/org/zalando/riptide/httpclient/StreamingApacheClientHttpRequest.java
+++ b/riptide-httpclient/src/main/java/org/zalando/riptide/httpclient/StreamingApacheClientHttpRequest.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -48,6 +49,12 @@ final class StreamingApacheClientHttpRequest implements ClientHttpRequest, Strea
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    @Nonnull
+    @Override
+    public Map<String, Object> getAttributes() {
+        throw new UnsupportedOperationException();
     }
 
     @Nonnull

--- a/riptide-httpclient/src/test/java/org/zalando/riptide/httpclient/BufferingApacheClientHttpRequestTest.java
+++ b/riptide-httpclient/src/test/java/org/zalando/riptide/httpclient/BufferingApacheClientHttpRequestTest.java
@@ -1,7 +1,10 @@
 package org.zalando.riptide.httpclient;
 
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.client.ClientHttpRequest;
 
 import java.net.URISyntaxException;
 
@@ -20,4 +23,13 @@ class BufferingApacheClientHttpRequestTest {
         assertThrows(IllegalArgumentException.class, request::getURI);
     }
 
+    @Test
+    void shouldNotSupportGetAttributes() {
+        final HttpClient client = mock(HttpClient.class);
+        final HttpPost request = new HttpPost("https://example.org");
+
+        final ClientHttpRequest unit = new BufferingApacheClientHttpRequest(client, request);
+
+        assertThrows(UnsupportedOperationException.class, unit::getAttributes);
+    }
 }

--- a/riptide-httpclient/src/test/java/org/zalando/riptide/httpclient/StreamingApacheClientHttpRequestTest.java
+++ b/riptide-httpclient/src/test/java/org/zalando/riptide/httpclient/StreamingApacheClientHttpRequestTest.java
@@ -51,4 +51,14 @@ final class StreamingApacheClientHttpRequestTest {
         assertThrows(IllegalArgumentException.class, request::getURI);
     }
 
+    @Test
+    void shouldNotSupportGetAttributes() {
+        final HttpClient client = mock(HttpClient.class);
+        final HttpPost request = new HttpPost("https://example.org");
+
+        final ClientHttpRequest unit = new StreamingApacheClientHttpRequest(client, request);
+
+        assertThrows(UnsupportedOperationException.class, unit::getAttributes);
+    }
+
 }


### PR DESCRIPTION
## Description

This PR updates Spring Framework version to 6.2.1 and replaces removed (deprecated) APIs to alternatives:
* removed `AbstractClientHttpResponse` abstract class was replaced to `ClientHttpResponse` interface

In Spring Framework 6.2 `org.springframework.http.HttpRequest` interface received a new method: `Map<String, Object> getAttributes()` without a default implementation. The PR doesn't implement the method and throw UnsupportedOperationException instead. It seems that this method is needed only for very rare use cases (like passing attributes to interceptors, see https://github.com/spring-projects/spring-framework/issues/32027). However, we can discuss if some implementation in Riptide makes sense.

## Motivation and Context

In Spring Framework 6.2 release several [deprecated APIs](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.2-Release-Notes#removed-apis) were removed. The current Riptide code uses some of them, in particular: `org.springframework.http.client.AbstractClientHttpResponse`.
The newest Spring Boot 3.4 release uses Spring Framework 6.2. The incompatibility of the current Riptide with Spring Framework 6.2 makes it impossible to upgrade services that use Riptide to the latest Spring Boot. ClassNotFoundException about `AbstractClientHttpResponse` is thrown at runtime.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [?] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
