### PR TITLE
Bumped opentelemetry-semconv to the latest version

### DIFF
--- a/riptide-opentelemetry/pom.xml
+++ b/riptide-opentelemetry/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <opentelemetry.version>1.39.0</opentelemetry.version>
-        <opentelemetry-semconv.version>1.25.0-alpha</opentelemetry-semconv.version>
+        <opentelemetry-semconv.version>1.30.0-rc.1</opentelemetry-semconv.version>
     </properties>
 
     <dependencyManagement>
@@ -47,6 +47,11 @@
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
             <version>${opentelemetry-semconv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv-incubating</artifactId>
+            <version>1.30.0-alpha-rc.1</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/riptide-opentelemetry/pom.xml
+++ b/riptide-opentelemetry/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <opentelemetry.version>1.39.0</opentelemetry.version>
-        <opentelemetry-semconv.version>1.30.0-rc.1</opentelemetry-semconv.version>
+        <opentelemetry-semconv.version>1.30.0</opentelemetry-semconv.version>
     </properties>
 
     <dependencyManagement>

--- a/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/HttpHostSpanDecorator.java
+++ b/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/HttpHostSpanDecorator.java
@@ -1,13 +1,13 @@
 package org.zalando.riptide.opentelemetry.span;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
 import org.zalando.riptide.RequestArguments;
 
 public class HttpHostSpanDecorator implements SpanDecorator {
 
     @Override
     public void onRequest(final Span span, final RequestArguments arguments) {
-        span.setAttribute(SemanticAttributes.HTTP_HOST, arguments.getRequestUri().getHost());
+        span.setAttribute(HttpIncubatingAttributes.HTTP_HOST, arguments.getRequestUri().getHost());
     }
 }

--- a/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/HttpMethodSpanDecorator.java
+++ b/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/HttpMethodSpanDecorator.java
@@ -1,13 +1,13 @@
 package org.zalando.riptide.opentelemetry.span;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
 import org.zalando.riptide.RequestArguments;
 
 public class HttpMethodSpanDecorator implements SpanDecorator {
 
     @Override
     public void onRequest(final Span span, final RequestArguments arguments) {
-        span.setAttribute(SemanticAttributes.HTTP_METHOD, arguments.getMethod().name());
+        span.setAttribute(HttpIncubatingAttributes.HTTP_METHOD, arguments.getMethod().name());
     }
 }

--- a/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/HttpStatusCodeSpanDecorator.java
+++ b/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/HttpStatusCodeSpanDecorator.java
@@ -1,7 +1,7 @@
 package org.zalando.riptide.opentelemetry.span;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
 import org.springframework.http.client.ClientHttpResponse;
 import org.zalando.riptide.HttpResponseException;
 import org.zalando.riptide.RequestArguments;
@@ -24,6 +24,6 @@ public class HttpStatusCodeSpanDecorator implements SpanDecorator {
     }
 
     private void setStatusCode(Span span, int statusCode) {
-        span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, statusCode);
+        span.setAttribute(HttpIncubatingAttributes.HTTP_STATUS_CODE, statusCode);
     }
 }

--- a/riptide-opentelemetry/src/test/java/org/zalando/riptide/opentelemetry/OpenTelemetryPluginTest.java
+++ b/riptide-opentelemetry/src/test/java/org/zalando/riptide/opentelemetry/OpenTelemetryPluginTest.java
@@ -10,7 +10,7 @@ import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.ExceptionAttributes;
 import lombok.SneakyThrows;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -204,9 +204,9 @@ class OpenTelemetryPluginTest {
         assertThat(events.size(), is(1));
 
         final Attributes eventAttributes = child.getEvents().get(0).getAttributes();
-        assertThat(eventAttributes.get(SemanticAttributes.EXCEPTION_TYPE), containsString("SocketTimeoutException"));
-        assertThat(eventAttributes.get(SemanticAttributes.EXCEPTION_MESSAGE), containsString("Read timed out"));
-        assertThat(eventAttributes.get(SemanticAttributes.EXCEPTION_STACKTRACE), is(notNullValue()));
+        assertThat(eventAttributes.get(ExceptionAttributes.EXCEPTION_TYPE), containsString("SocketTimeoutException"));
+        assertThat(eventAttributes.get(ExceptionAttributes.EXCEPTION_MESSAGE), containsString("Read timed out"));
+        assertThat(eventAttributes.get(ExceptionAttributes.EXCEPTION_STACKTRACE), is(notNullValue()));
 
         verify(server, 1, "/");
     }


### PR DESCRIPTION
## Description
Latest Obversaviblity SDK 3.1.13 contains a bump of `opentelemetry-semconv`from 1.28.0-alpha to 1.30.0-rc.1 introducing a breaking change as the `io.opentelemetry.semconv.SemanticAttributes` class was removed and replaced with more specific sub class in the sub package `incubating`.

Nevertheless, looking at the class it had the deprecation marker since version 1.24.0 (Riptide uses 1.25-alpha currently), so I guess, it is the usual issue that these deprecation warnings are overlooked until it is too late.

## Motivation and Context
It allows projects using Obversaviblity SDK to use the latest version.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)