### PR TITLE
Remove Maven OWASP dependency check plugin

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,6 @@ env:
     -Dhttp.keepAlive=false
     -Dmaven.wagon.http.pool=false
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-  NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -87,10 +87,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.basepom.maven</groupId>
                 <artifactId>duplicate-finder-maven-plugin</artifactId>
             </plugin>
@@ -118,26 +114,6 @@
                             </configuration>
                         </execution>
                     </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>11.1.1</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <failBuildOnCVSS>0</failBuildOnCVSS>
-                        <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                        <suppressionFiles>
-                            <suppressionFile>cve-suppressions.xml</suppressionFile>
-                        </suppressionFiles>
-                        <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.basepom.maven</groupId>


### PR DESCRIPTION
As seen in the latest build of #1700, the downloading of the CVE database in the OWAP dependency-check plugin takes a lot of time in case you don't have a specific key. As also another Zalando repository was affected by this, the recommendation is to remove it and rely on on GitHub's dependabot integration.