### PR TITLE
ISSUE-1660 Auto configuration for OpenTelemetry HTTP retry attributes

### DIFF
--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactory.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactory.java
@@ -2,7 +2,12 @@ package org.zalando.riptide.autoconfigure;
 
 import org.zalando.riptide.Plugin;
 import org.zalando.riptide.opentelemetry.OpenTelemetryPlugin;
+import org.zalando.riptide.opentelemetry.span.RetrySpanDecorator;
+import org.zalando.riptide.opentelemetry.span.SpanDecorator;
 import org.zalando.riptide.opentelemetry.span.StaticSpanDecorator;
+
+import java.util.ArrayList;
+import java.util.List;
 
 final class OpenTelemetryPluginFactory {
     private OpenTelemetryPluginFactory() {
@@ -10,7 +15,11 @@ final class OpenTelemetryPluginFactory {
     }
 
     public static Plugin create(final RiptideProperties.Client client) {
-        StaticSpanDecorator decorator = new StaticSpanDecorator(client.getTelemetry().getAttributes());
-        return new OpenTelemetryPlugin(decorator);
+        final List<SpanDecorator> decorators = new ArrayList<>();
+        decorators.add(new StaticSpanDecorator(client.getTelemetry().getAttributes()));
+        if (client.getRetry().getEnabled()) {
+            decorators.add(new RetrySpanDecorator());
+        }
+        return new OpenTelemetryPlugin(decorators.toArray(new SpanDecorator[0]));
     }
 }

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactoryTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactoryTest.java
@@ -1,0 +1,90 @@
+package org.zalando.riptide.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.util.ReflectionUtils;
+import org.zalando.riptide.Plugin;
+import org.zalando.riptide.opentelemetry.OpenTelemetryPlugin;
+import org.zalando.riptide.opentelemetry.span.CompositeSpanDecorator;
+import org.zalando.riptide.opentelemetry.span.RetrySpanDecorator;
+import org.zalando.riptide.opentelemetry.span.SpanDecorator;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpenTelemetryPluginFactoryTest {
+
+    private static final Field SPAN_DECORATOR_FIELD = ReflectionUtils.findField(OpenTelemetryPlugin.class, "spanDecorator");
+    private static final Field DECORATORS_FIELD = ReflectionUtils.findField(CompositeSpanDecorator.class, "decorators");
+
+    static {
+        SPAN_DECORATOR_FIELD.setAccessible(true);
+        DECORATORS_FIELD.setAccessible(true);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, RetrySpanDecorator should be added when retry is enabled",
+        "false, RetrySpanDecorator should not be added when retry is disabled"
+    })
+    void shouldCreatePluginWithRetrySpanDecoratorWhenClientRetryEnabled(
+            final boolean isRetryEnabled,
+            final String message
+    ) throws IllegalAccessException {
+        final Plugin plugin = OpenTelemetryPluginFactory.create(createTestClient(isRetryEnabled));
+
+        assertNotNull(plugin);
+        assertInstanceOf(OpenTelemetryPlugin.class, plugin);
+
+        final Optional<SpanDecorator> innerCompositeDecorator = StreamSupport.stream(
+                ((Iterable<SpanDecorator>) DECORATORS_FIELD.get(SPAN_DECORATOR_FIELD.get(plugin))).spliterator(), false
+        ).filter(decorator -> decorator instanceof CompositeSpanDecorator).findFirst();
+
+        assertThat(innerCompositeDecorator).isPresent();
+        assertThat(
+            StreamSupport.stream(
+                ((Iterable<SpanDecorator>) DECORATORS_FIELD.get(innerCompositeDecorator.get())).spliterator(), false
+            ).anyMatch(decorator -> decorator instanceof RetrySpanDecorator)
+        ).withFailMessage(message).isEqualTo(isRetryEnabled);
+    }
+
+    @Test
+    void shouldCreatePluginWithoutRetrySpanDecorator() throws IllegalAccessException {
+        final Plugin plugin = OpenTelemetryPluginFactory.create(createTestClient(false));
+
+        assertNotNull(plugin);
+        assertInstanceOf(OpenTelemetryPlugin.class, plugin);
+
+        final Optional<SpanDecorator> innerCompositeDecorator = StreamSupport.stream(
+            ((Iterable<SpanDecorator>) DECORATORS_FIELD.get(SPAN_DECORATOR_FIELD.get(plugin))).spliterator(), false
+        ).filter(decorator -> decorator instanceof CompositeSpanDecorator).findFirst();
+
+        assertThat(innerCompositeDecorator).isPresent();
+        assertTrue(
+            StreamSupport.stream(
+                ((Iterable<SpanDecorator>) DECORATORS_FIELD.get(innerCompositeDecorator.get())).spliterator(), false
+            ).noneMatch(decorator -> decorator instanceof RetrySpanDecorator),
+            "RetrySpanDecorator should not be added when retry is disabled"
+        );
+    }
+
+    private static RiptideProperties.Client createTestClient(final boolean retryEnabled) {
+        final RiptideProperties.Client client = new RiptideProperties.Client();
+        final RiptideProperties.Telemetry telemetry = new RiptideProperties.Telemetry();
+        telemetry.setAttributes(Map.of("service.name", "test-service"));
+        client.setTelemetry(telemetry);
+
+        final RiptideProperties.Retry retry = new RiptideProperties.Retry();
+        retry.setEnabled(retryEnabled);
+        client.setRetry(retry);
+
+        return client;
+    }
+
+}

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactoryTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactoryTest.java
@@ -18,7 +18,7 @@ import java.util.stream.StreamSupport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-class OpenTelemetryPluginFactoryTest {
+public class OpenTelemetryPluginFactoryTest {
 
     private static final Field SPAN_DECORATOR_FIELD = ReflectionUtils.findField(OpenTelemetryPlugin.class, "spanDecorator");
     private static final Field DECORATORS_FIELD = ReflectionUtils.findField(CompositeSpanDecorator.class, "decorators");


### PR DESCRIPTION
This PR introduces **auto-configuration** for OpenTelemetry HTTP retry attributes, providing seamless integration and enhanced observability for HTTP client retry behavior in Spring-based applications.

#### Summary of Changes:
- Enhanced OpenTelemetry plugin factory to include **RetrySpanDecorator** into a list of pre-configured decorators when client retry logic is enabled.

#### Why is this change necessary?
This feature simplifies the process of enabling HTTP retry observability for Spring applications by leveraging Spring Boot's auto-configuration mechanism. Developers using the Spring ecosystem can now gain actionable insights into HTTP retry behavior without requiring manual setup. This contributes to better debugging, performance monitoring, and alignment with OpenTelemetry standards.

**Related Issue:**  
- Resolves **[ISSUE-1600](https://github.bus.zalan.do/Bowser/roadmap/issues/1660)**

