### PR TITLE
ISSUE-240 OpenTelemetry propagate flow-id via HTTP client headers and…

### DIFF
--- a/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/ExtensionAttributes.java
+++ b/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/ExtensionAttributes.java
@@ -3,6 +3,7 @@ package org.zalando.riptide.opentelemetry.span;
 import io.opentelemetry.api.common.AttributeKey;
 
 public class ExtensionAttributes {
+    public static final AttributeKey<String> FLOW_ID = AttributeKey.stringKey("flow_id");
     public static final AttributeKey<String> HTTP_PATH = AttributeKey.stringKey("http.path");
     public static final AttributeKey<Boolean> RETRY = AttributeKey.booleanKey("retry");
     public static final AttributeKey<String> PEER_HOST = AttributeKey.stringKey("peer.hostname");

--- a/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/FlowIdSpanDecorator.java
+++ b/riptide-opentelemetry/src/main/java/org/zalando/riptide/opentelemetry/span/FlowIdSpanDecorator.java
@@ -1,0 +1,31 @@
+package org.zalando.riptide.opentelemetry.span;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import org.zalando.riptide.RequestArguments;
+
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+
+import static org.zalando.riptide.opentelemetry.span.ExtensionAttributes.FLOW_ID;
+
+@RequiredArgsConstructor
+public class FlowIdSpanDecorator implements SpanDecorator {
+
+    public static final String FLOW_ID_HEADER = "X-Flow-ID";
+
+    private final boolean propagateFlowId;
+
+    @Override
+    public void onRequest(Span span, RequestArguments arguments) {
+        Optional.ofNullable(Baggage.current().getEntryValue(FLOW_ID.getKey()))
+            .ifPresent(flowId -> {
+                span.setAttribute(FLOW_ID, flowId);
+
+                if (propagateFlowId) {
+                    arguments.withHeader(FLOW_ID_HEADER, flowId);
+                }
+            });
+    }
+}

--- a/riptide-opentelemetry/src/test/java/org/zalando/riptide/opentelemetry/span/FlowIdSpanDecoratorTest.java
+++ b/riptide-opentelemetry/src/test/java/org/zalando/riptide/opentelemetry/span/FlowIdSpanDecoratorTest.java
@@ -1,0 +1,73 @@
+package org.zalando.riptide.opentelemetry.span;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.zalando.riptide.RequestArguments;
+
+import static org.mockito.Mockito.*;
+
+class FlowIdSpanDecoratorTest {
+
+    private static final String FLOW_ID = "flow-id-value";
+    private static final String FLOW_ID_HEADER = "X-Flow-ID";
+
+    private Span span;
+    private RequestArguments arguments;
+
+    @BeforeEach
+    void setUp() {
+        span = mock(Span.class);
+        arguments = mock(RequestArguments.class);
+    }
+
+    @Test
+    void shouldSetFlowIdAttributeAndPropagateHeaderWhenEnabled() {
+        final FlowIdSpanDecorator decorator = new FlowIdSpanDecorator(true);
+        final Baggage baggage = mock(Baggage.class);
+        when(baggage.getEntryValue(ExtensionAttributes.FLOW_ID.getKey())).thenReturn(FLOW_ID);
+
+        try (MockedStatic<Baggage> mockedBaggage = mockStatic(Baggage.class)) {
+            mockedBaggage.when(Baggage::current).thenReturn(baggage);
+
+            decorator.onRequest(span, arguments);
+
+            verify(span).setAttribute(ExtensionAttributes.FLOW_ID, FLOW_ID);
+            verify(arguments).withHeader(FLOW_ID_HEADER, FLOW_ID);
+        }
+    }
+
+    @Test
+    void shouldSetFlowIdAttributeWithoutPropagatingHeaderWhenDisabled() {
+        final FlowIdSpanDecorator decorator = new FlowIdSpanDecorator(false);
+        final Baggage baggage = mock(Baggage.class);
+        when(baggage.getEntryValue(ExtensionAttributes.FLOW_ID.getKey())).thenReturn(FLOW_ID);
+
+        try (MockedStatic<Baggage> mockedBaggage = mockStatic(Baggage.class)) {
+            mockedBaggage.when(Baggage::current).thenReturn(baggage);
+
+            decorator.onRequest(span, arguments);
+
+            verify(span).setAttribute(ExtensionAttributes.FLOW_ID, FLOW_ID);
+            verify(arguments, never()).withHeader(FLOW_ID_HEADER, FLOW_ID);
+        }
+    }
+
+    @Test
+    void shouldDoNothingWhenFlowIdIsAbsent() {
+        final FlowIdSpanDecorator decorator = new FlowIdSpanDecorator(true);
+        final Baggage baggage = mock(Baggage.class);
+        when(baggage.getEntryValue(ExtensionAttributes.FLOW_ID.getKey())).thenReturn(null);
+
+        try (MockedStatic<Baggage> mockedBaggage = mockStatic(Baggage.class)) {
+            mockedBaggage.when(Baggage::current).thenReturn(baggage);
+
+            decorator.onRequest(span, arguments);
+
+            verify(span, never()).setAttribute(anyString(), anyString());
+            verify(arguments, never()).withHeader(anyString(), anyString());
+        }
+    }
+}

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Defaulting.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/Defaulting.java
@@ -306,7 +306,8 @@ final class Defaulting {
     private static Telemetry merge(final Telemetry base, final Telemetry defaults) {
         return new Telemetry(
                 either(base.getEnabled(), defaults.getEnabled()),
-                merge(base.getAttributes(), defaults.getAttributes(), Defaulting::merge)
+                merge(base.getAttributes(), defaults.getAttributes(), Defaulting::merge),
+                either(base.getPropagateFlowId(), defaults.getPropagateFlowId())
         );
     }
 

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactory.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactory.java
@@ -2,6 +2,7 @@ package org.zalando.riptide.autoconfigure;
 
 import org.zalando.riptide.Plugin;
 import org.zalando.riptide.opentelemetry.OpenTelemetryPlugin;
+import org.zalando.riptide.opentelemetry.span.FlowIdSpanDecorator;
 import org.zalando.riptide.opentelemetry.span.RetrySpanDecorator;
 import org.zalando.riptide.opentelemetry.span.SpanDecorator;
 import org.zalando.riptide.opentelemetry.span.StaticSpanDecorator;
@@ -16,10 +17,12 @@ final class OpenTelemetryPluginFactory {
 
     public static Plugin create(final RiptideProperties.Client client) {
         final List<SpanDecorator> decorators = new ArrayList<>();
-        decorators.add(new StaticSpanDecorator(client.getTelemetry().getAttributes()));
+        final var clientTelemetryConfig = client.getTelemetry();
+        decorators.add(new StaticSpanDecorator(clientTelemetryConfig.getAttributes()));
         if (client.getRetry().getEnabled()) {
             decorators.add(new RetrySpanDecorator());
         }
+        decorators.add(new FlowIdSpanDecorator(clientTelemetryConfig.getPropagateFlowId()));
         return new OpenTelemetryPlugin(decorators.toArray(new SpanDecorator[0]));
     }
 }

--- a/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/RiptideProperties.java
+++ b/riptide-spring-boot-autoconfigure/src/main/java/org/zalando/riptide/autoconfigure/RiptideProperties.java
@@ -132,7 +132,7 @@ public final class RiptideProperties {
         private Tracing tracing = new Tracing(false, emptyMap(), false);
 
         @NestedConfigurationProperty
-        private Telemetry telemetry = new Telemetry(false, emptyMap());
+        private Telemetry telemetry = new Telemetry(false, emptyMap(), false);
 
         @NestedConfigurationProperty
         private Chaos chaos = new Chaos(
@@ -419,6 +419,7 @@ public final class RiptideProperties {
     public static final class Telemetry {
         private Boolean enabled;
         private Map<String, String> attributes;
+        private Boolean propagateFlowId;
     }
 
     @Getter

--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactoryTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/OpenTelemetryPluginFactoryTest.java
@@ -1,12 +1,12 @@
 package org.zalando.riptide.autoconfigure;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.util.ReflectionUtils;
 import org.zalando.riptide.Plugin;
 import org.zalando.riptide.opentelemetry.OpenTelemetryPlugin;
 import org.zalando.riptide.opentelemetry.span.CompositeSpanDecorator;
+import org.zalando.riptide.opentelemetry.span.FlowIdSpanDecorator;
 import org.zalando.riptide.opentelemetry.span.RetrySpanDecorator;
 import org.zalando.riptide.opentelemetry.span.SpanDecorator;
 
@@ -16,16 +16,17 @@ import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 public class OpenTelemetryPluginFactoryTest {
 
     private static final Field SPAN_DECORATOR_FIELD = ReflectionUtils.findField(OpenTelemetryPlugin.class, "spanDecorator");
     private static final Field DECORATORS_FIELD = ReflectionUtils.findField(CompositeSpanDecorator.class, "decorators");
+    private static final Field PROPAGATE_FLOW_ID_FIELD = ReflectionUtils.findField(FlowIdSpanDecorator.class, "propagateFlowId");
 
     static {
         SPAN_DECORATOR_FIELD.setAccessible(true);
         DECORATORS_FIELD.setAccessible(true);
+        PROPAGATE_FLOW_ID_FIELD.setAccessible(true);
     }
 
     @ParameterizedTest
@@ -33,51 +34,101 @@ public class OpenTelemetryPluginFactoryTest {
         "true, RetrySpanDecorator should be added when retry is enabled",
         "false, RetrySpanDecorator should not be added when retry is disabled"
     })
-    void shouldCreatePluginWithRetrySpanDecoratorWhenClientRetryEnabled(
-            final boolean isRetryEnabled,
-            final String message
+    void shouldAddRetrySpanDecoratorWhenEnabled(
+        final boolean isRetryEnabled,
+        final String message
     ) throws IllegalAccessException {
-        final Plugin plugin = OpenTelemetryPluginFactory.create(createTestClient(isRetryEnabled));
+        final Plugin plugin = OpenTelemetryPluginFactory.create(createTestClient(isRetryEnabled, false));
 
-        assertNotNull(plugin);
-        assertInstanceOf(OpenTelemetryPlugin.class, plugin);
+        assertThat(plugin)
+            .isNotNull()
+            .isInstanceOf(OpenTelemetryPlugin.class);
 
-        final Optional<SpanDecorator> innerCompositeDecorator = StreamSupport.stream(
-                ((Iterable<SpanDecorator>) DECORATORS_FIELD.get(SPAN_DECORATOR_FIELD.get(plugin))).spliterator(), false
-        ).filter(decorator -> decorator instanceof CompositeSpanDecorator).findFirst();
-
-        assertThat(innerCompositeDecorator).isPresent();
-        assertThat(
-            StreamSupport.stream(
-                ((Iterable<SpanDecorator>) DECORATORS_FIELD.get(innerCompositeDecorator.get())).spliterator(), false
-            ).anyMatch(decorator -> decorator instanceof RetrySpanDecorator)
-        ).withFailMessage(message).isEqualTo(isRetryEnabled);
-    }
-
-    @Test
-    void shouldCreatePluginWithoutRetrySpanDecorator() throws IllegalAccessException {
-        final Plugin plugin = OpenTelemetryPluginFactory.create(createTestClient(false));
-
-        assertNotNull(plugin);
-        assertInstanceOf(OpenTelemetryPlugin.class, plugin);
-
-        final Optional<SpanDecorator> innerCompositeDecorator = StreamSupport.stream(
-            ((Iterable<SpanDecorator>) DECORATORS_FIELD.get(SPAN_DECORATOR_FIELD.get(plugin))).spliterator(), false
-        ).filter(decorator -> decorator instanceof CompositeSpanDecorator).findFirst();
-
-        assertThat(innerCompositeDecorator).isPresent();
-        assertTrue(
-            StreamSupport.stream(
-                ((Iterable<SpanDecorator>) DECORATORS_FIELD.get(innerCompositeDecorator.get())).spliterator(), false
-            ).noneMatch(decorator -> decorator instanceof RetrySpanDecorator),
-            "RetrySpanDecorator should not be added when retry is disabled"
+        final Optional<CompositeSpanDecorator> innerCompositeDecorator = getDecorator(
+            (SpanDecorator) SPAN_DECORATOR_FIELD.get(plugin),
+            CompositeSpanDecorator.class
         );
+
+        assertThat(innerCompositeDecorator).isPresent();
+        assertThat(getDecorator(innerCompositeDecorator.get(), RetrySpanDecorator.class).isPresent())
+            .withFailMessage(message)
+            .isEqualTo(isRetryEnabled);
     }
 
-    private static RiptideProperties.Client createTestClient(final boolean retryEnabled) {
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, FlowIdSpanDecorator should be added when client telemetry is enabled",
+        "false, FlowIdSpanDecorator should be added when client telemetry is disabled"
+    })
+    void shouldAlwaysAddFlowIdSpanDecorator(
+        final boolean isFlowIdPropagationEnabled,
+        final String message
+    ) throws IllegalAccessException {
+        final Plugin plugin = OpenTelemetryPluginFactory.create(createTestClient(false, isFlowIdPropagationEnabled));
+
+        assertThat(plugin)
+            .isNotNull()
+            .isInstanceOf(OpenTelemetryPlugin.class);
+
+        final Optional<CompositeSpanDecorator> innerCompositeDecorator = getDecorator(
+            (SpanDecorator) SPAN_DECORATOR_FIELD.get(plugin),
+            CompositeSpanDecorator.class
+        );
+
+        assertThat(innerCompositeDecorator).isPresent();
+        assertThat(getDecorator(innerCompositeDecorator.get(), FlowIdSpanDecorator.class))
+            .withFailMessage(message)
+            .isPresent();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, flow id propagation should be enabled",
+        "false, flow id propagation should be enabled be disabled"
+    })
+    void shouldAddFlowIdHeaderWhenPropagateFlowIdEnabled(
+        final boolean isFlowIdPropagationEnabled,
+        final String message
+    ) throws IllegalAccessException {
+        final Plugin plugin = OpenTelemetryPluginFactory.create(createTestClient(false, isFlowIdPropagationEnabled));
+
+        assertThat(plugin)
+            .isNotNull()
+            .isInstanceOf(OpenTelemetryPlugin.class);
+
+        final Optional<CompositeSpanDecorator> innerCompositeDecorator = getDecorator(
+            (SpanDecorator) SPAN_DECORATOR_FIELD.get(plugin),
+            CompositeSpanDecorator.class
+        );
+
+        assertThat(innerCompositeDecorator).isPresent();
+
+        final Optional<FlowIdSpanDecorator> decoratorCandidate = getDecorator(innerCompositeDecorator.get(), FlowIdSpanDecorator.class);
+        assertThat(decoratorCandidate).isNotEmpty();
+
+        final FlowIdSpanDecorator decorator = decoratorCandidate.get();
+        assertThat(PROPAGATE_FLOW_ID_FIELD.getBoolean(decorator))
+            .withFailMessage(message)
+            .isEqualTo(isFlowIdPropagationEnabled);
+    }
+
+    private static <T extends SpanDecorator> Optional<T> getDecorator(
+        final SpanDecorator decorator,
+        final Class<T> decoratorType
+    ) throws IllegalAccessException {
+        return StreamSupport.stream(((Iterable<SpanDecorator>) DECORATORS_FIELD.get(decorator)).spliterator(), false)
+            .filter(decoratorType::isInstance)
+            .map(decoratorType::cast)
+            .findFirst();
+    }
+
+    private static RiptideProperties.Client createTestClient(final boolean retryEnabled,
+                                                             final boolean propagateFlowId) {
         final RiptideProperties.Client client = new RiptideProperties.Client();
         final RiptideProperties.Telemetry telemetry = new RiptideProperties.Telemetry();
         telemetry.setAttributes(Map.of("service.name", "test-service"));
+        telemetry.setPropagateFlowId(propagateFlowId);
         client.setTelemetry(telemetry);
 
         final RiptideProperties.Retry retry = new RiptideProperties.Retry();


### PR DESCRIPTION
This PR introduces **auto-configuration** for OpenTelemetry HTTP client `flow-id` propagation and providing seamless integration and enhanced observability for HTTP client in Spring-based applications.

#### Summary of Changes:
- FlowIdSpanDecorator is added to add flow-id attribute to HTTP client spans and optionally propagate flow-id via HTTP headers
- Enhanced OpenTelemetry plugin factory to include **FlowIdSpanDecorator** into a list of pre-configured decorators when client retry logic is enabled

#### Why is this change necessary?
Propagate Flow ID across the application to ensure consistent tracking and logging of request flows. Updated relevant classes and methods to include Flow ID handling. This contributes to better debugging, performance monitoring, and alignment with OpenTelemetry standards.

**Related Issue:**  
- Resolves **[return-steering-service/ISSUE-240](https://github.bus.zalan.do/Bowser/return-steering-service/issues/240)**

