### PR TITLE
Clarify retry semantics, fault types, and transient-fault-detection requirement

### DIFF
--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -67,16 +67,17 @@ riptide.clients:
       jitter: 25 milliseconds
 ```
 
-**What `retry:` config controls:** timing, backoff, jitter, and limits. It does **not** make
-Riptide retry arbitrary `4xx` or `5xx` responses automatically.
+**What `retry:` config controls:** timing, backoff, jitter, and limits. It does **not** by
+itself enable automatic retries for transport faults — enabling `retry:` alone only makes
+explicit `retry()` / `RetryException` retries respect the configured limits.
 
-**How retries are triggered:**
+**How retries are triggered (Spring Boot auto-config path):**
 
-| Trigger | Description |
-|---|---|
-| Socket fault (e.g. read timeout) | Automatic, but only for [safe and idempotent](../riptide-failsafe#safe-and-idempotent-methods) methods |
-| Connection fault (e.g. connection refused) | In the Spring Boot auto-config path, enabling [transient fault detection](../riptide-faults) adds a separate retry policy for transient connection faults that can apply to all methods |
-| Response-based (e.g. `503`) | Explicit — use `retry()` route or throw `RetryException` in your routing callback |
+| Trigger | Condition | Description |
+|---|---|---|
+| Socket fault (e.g. read timeout) | `retry` + `transient-fault-detection.enabled: true` | Automatic, but only for [safe and idempotent](../riptide-failsafe#safe-and-idempotent-methods) methods |
+| Connection fault (e.g. connection refused) | `retry` + `transient-fault-detection.enabled: true` | Automatic for **all** methods — a connection never established means the request never reached the server |
+| Response-based (e.g. `503`) | `retry` only (no transient fault detection needed) | Explicit — use `retry()` route or throw `RetryException` in your routing callback |
 
 `Retry-After` and `X-RateLimit-Reset` headers influence how long Riptide waits before the next
 attempt; they do not make a response eligible for retry on their own.

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -67,6 +67,23 @@ riptide.clients:
       jitter: 25 milliseconds
 ```
 
+**What `retry:` config controls:** timing, backoff, jitter, and limits. It does **not** make
+Riptide retry arbitrary `4xx` or `5xx` responses automatically.
+
+**How retries are triggered:**
+
+| Trigger | Description |
+|---|---|
+| Socket fault (e.g. read timeout) | Automatic, but only for [safe and idempotent](../riptide-failsafe#safe-and-idempotent-methods) methods |
+| Connection fault (e.g. connection refused) | In the Spring Boot auto-config path, enabling [transient fault detection](../riptide-faults) adds a separate retry policy for transient connection faults that can apply to all methods |
+| Response-based (e.g. `503`) | Explicit — use `retry()` route or throw `RetryException` in your routing callback |
+
+`Retry-After` and `X-RateLimit-Reset` headers influence how long Riptide waits before the next
+attempt; they do not make a response eligible for retry on their own.
+
+For detailed semantics, idempotency rules, and code examples see
+[riptide-failsafe](../riptide-failsafe).
+
 ## Circuit Breaker
 
 > Handle faults that might take a variable amount of time to recover from, when connecting to a remote service or resource. This can improve the stability and resiliency of an application.

--- a/riptide-failsafe/README.md
+++ b/riptide-failsafe/README.md
@@ -67,6 +67,27 @@ Please visit the [Failsafe readme](https://github.com/jhalterman/failsafe#readme
 
 ### Retries
 
+**What retry config controls:** The `RetryPolicy` controls timing, backoff, jitter, and limits.
+Enabling retry config does **not** make Riptide automatically retry arbitrary `4xx` or `5xx`
+responses.
+
+**How retries are triggered:**
+
+- **Socket faults** (e.g. read timeout) — Riptide retries automatically, but only for
+  [safe and idempotent methods](#safe-and-idempotent-methods). Non-idempotent requests are
+  not retried on socket timeout unless you explicitly mark them idempotent.
+- **Connection faults** (e.g. connection refused) — When using the Spring Boot auto-config
+  path with `transient-fault-detection.enabled: true`, connection faults are retried for
+  **all** methods (idempotent or not), because a connection that was never established
+  means the request never reached the server. Without that auto-configured transient fault
+  detection path, configure a retry policy for connection faults explicitly.
+- **Response-based retries** — You must trigger these explicitly, either by calling `retry()`
+  in your routing callback or by throwing `RetryException`. Receiving a `503` does not cause
+  a retry by itself.
+
+`Retry-After` and `X-RateLimit-Reset` headers influence the delay between retries once a retry
+has already been triggered; they do not make a response eligible for retry on their own.
+
 **Beware** when using `retryOn` to retry conditionally on certain exception types.
 You'll need to register `RetryException` in order for the `retry()` route to work:
 
@@ -88,10 +109,21 @@ retryClient.get()
                     throw new RetryException(response); // we will retry this one
                 }  else {
                     throw new AnyOtherException(response); // we wont retry this one
-                }  
+                }
             }
         )
     ).join()
+```
+
+To explicitly retry a `503 Service Unavailable`:
+
+```java
+http.get("/users/me")
+    .dispatch(series(),
+        on(SUCCESSFUL).call(User.class, this::greet),
+        on(SERVER_ERROR).dispatch(status(),
+            on(SERVICE_UNAVAILABLE).call(retry())),
+        anySeries().call(problemHandling()))
 ```
 
 Failsafe supports dynamically computed delays using a custom function.

--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -125,13 +125,16 @@ Required for `retry`, `circuit-breaker`, `backup-request` and `timeout` support.
 ```
 
 > **Retry semantics:** The `retry:` configuration controls timing, backoff, jitter, and limits.
-> It does **not** make Riptide automatically retry arbitrary `4xx` or `5xx` responses.
-> Socket faults are retried automatically for safe and idempotent methods only.
-> Connection faults are retried for **all** methods when `transient-fault-detection.enabled: true`
-> is set (because a connection that never reached the server is safe to re-send).
+> It does **not** by itself enable automatic retries for transport faults.
+>
+> | Config combination | What retries automatically |
+> |---|---|
+> | `retry` only | Nothing — only explicit `retry()` / `RetryException` in your routing callback |
+> | `retry` + `transient-fault-detection` | Socket faults (safe/idempotent methods only); connection faults (all methods) |
+>
 > To retry on a specific response status (e.g. `503`), use the `retry()` route or throw
-> `RetryException` in your routing callback. See [riptide-failsafe](../riptide-failsafe) for
-> details.
+> `RetryException` in your routing callback regardless of which combination above you use.
+> See [riptide-failsafe](../riptide-failsafe) for details.
 
 #### [Transient Fault](../riptide-faults) detection
 

--- a/riptide-spring-boot-autoconfigure/README.md
+++ b/riptide-spring-boot-autoconfigure/README.md
@@ -124,6 +124,15 @@ Required for `retry`, `circuit-breaker`, `backup-request` and `timeout` support.
 </dependency>
 ```
 
+> **Retry semantics:** The `retry:` configuration controls timing, backoff, jitter, and limits.
+> It does **not** make Riptide automatically retry arbitrary `4xx` or `5xx` responses.
+> Socket faults are retried automatically for safe and idempotent methods only.
+> Connection faults are retried for **all** methods when `transient-fault-detection.enabled: true`
+> is set (because a connection that never reached the server is safe to re-send).
+> To retry on a specific response status (e.g. `503`), use the `retry()` route or throw
+> `RetryException` in your routing callback. See [riptide-failsafe](../riptide-failsafe) for
+> details.
+
 #### [Transient Fault](../riptide-faults) detection
 
 Required when `transient-fault-detection` is enabled.


### PR DESCRIPTION
Clarifies retry semantics around idempotency, fault types, and response-based retries in riptide-failsafe and spring-boot-autoconfigure READs.
Fixes socket-fault retry docs to correctly require transient-fault-detection instead of being standalone.
Adds consolidated resilience docs overview at docs/resilience.md.

Closes https://github.com/zalando/riptide/issues/952