### PR TITLE
Add riptide-example-basic onboarding module

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,41 @@ protocol and Java. Riptide allows users to leverage the power of HTTP with its u
  - **Upgrading from 3.x to 4.x?** Please refer to the [Migration Guide](MIGRATION.md#riptide-40-migration-guide).
  - **Upgrading from 2.x to 3.x?** Please refer to the [Migration Guide](MIGRATION.md#riptide-30-migration-guide).
 
+## Getting Started
+
+New to Riptide? Start here:
+
+1. **Pick your dependency** – see the table below.
+2. **Run the [basic example](riptide-example-basic)** – a self-contained module with complete imports and tests.
+3. **Read [docs/concepts.md](docs/concepts.md)** – explains routing trees, navigators, and bindings.
+
+### Dependency quick-reference
+
+| Use case | Dependency |
+|---|---|
+| Minimal / manual client | `riptide-core` |
+| Spring Boot application | `riptide-spring-boot-starter` |
+| Retries, circuit breaker, timeouts | `riptide-failsafe` |
+| Transient fault detection (socket errors) | `riptide-faults` |
+
 ## Example
 
 Usage typically looks like this:
 
 ```java
+import static org.springframework.http.HttpStatus.Series.SUCCESSFUL;
+import static org.zalando.riptide.Bindings.on;
+import static org.zalando.riptide.Navigators.series;
+import static org.zalando.riptide.Types.listOf;
+
 http.get("/repos/{org}/{repo}/contributors", "zalando", "riptide")
     .dispatch(series(),
-        on(SUCCESSFUL).call(listOf(User.class), users -> 
+        on(SUCCESSFUL).call(listOf(User.class), users ->
             users.forEach(System.out::println)));
 ```
+
+For a complete runnable example with full imports — including redirect routing and body
+deserialization — see the **[riptide-example-basic](riptide-example-basic)** module.
 
 Feel free to compare this e.g. to [Feign](https://github.com/Netflix/feign#basics) or
 [Retrofit](https://github.com/square/retrofit/blob/master/samples/src/main/java/com/example/retrofit/SimpleService.java).
@@ -290,7 +315,10 @@ The `Content-Type`- and `Accept`-header have type-safe methods in addition to th
 
 Riptide is special in the way it handles responses. Rather than having a single return value, you need to register
 callbacks. Traditionally, you would attach different callbacks for different response status codes. Alternatively, there
-are built-in routing capabilities on status code families (called series in Spring) as well as on content types. 
+are built-in routing capabilities on status code families (called series in Spring) as well as on content types.
+
+See [docs/concepts.md](docs/concepts.md) for an explanation of routing trees, navigators, and bindings.
+See [riptide-example-basic](riptide-example-basic) for a complete runnable example with full imports.
 
 ```java
 http.post("/sales-order")

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -56,3 +56,40 @@ on(SUCCESSFUL).dispatch(contentType(),
 | `ThrowingConsumer<T>`                  | `on(..).call(Class<T>, ThrowingConsumer<T>)`        |
 | `ThrowingConsumer<T>`                  | `on(..).call(TypeToken<T>, ThrowingConsumer<T>)`    |
 | `RoutingTree`                          | `on(..).dispatch(..)`                               |
+
+### Common Patterns
+
+#### Redirect routing — extracting a Location header
+
+A route is a callback over `ClientHttpResponse` or a decoded body. To inspect a response header,
+use `on(..).call(ThrowingConsumer<ClientHttpResponse>)`:
+
+```java
+http.get("/start")
+    .dispatch(series(),
+        on(REDIRECTION).call(response -> {
+            URI next = response.getHeaders().getLocation();
+            // continue with next request or store URI
+        }));
+```
+
+> **Note on automatic redirect following:** The Apache HTTP client (used by default) follows
+> redirects automatically, so a `3xx` response may never reach your routing callback unless you
+> disable redirect handling on the client. To observe `Location` headers yourself, configure
+> `HttpClientCustomizer` to call `builder.disableRedirectHandling()`. See
+> [riptide-example-basic](../riptide-example-basic) for a working example.
+
+#### Body deserialization
+
+To decode the response body into a typed object, pass the target class as the first argument:
+
+```java
+http.get("/users/me")
+    .dispatch(series(),
+        on(SUCCESSFUL).call(User.class, user -> {
+            // user is already deserialized
+        }));
+```
+
+For a complete, runnable example with full imports — including both patterns above — see
+[riptide-example-basic](../riptide-example-basic).

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <module>riptide-spring-boot-autoconfigure</module>
         <module>riptide-spring-boot-starter</module>
         <module>riptide-stream</module>
+        <module>riptide-example-basic</module>
     </modules>
 
     <properties>

--- a/riptide-example-basic/README.md
+++ b/riptide-example-basic/README.md
@@ -1,0 +1,53 @@
+# Riptide: Example (Basic)
+
+This module is a runnable onboarding example. It demonstrates the core Riptide API through the
+Spring Boot starter path, with complete imports and a real test.
+
+## What it shows
+
+- Wiring an `Http` client via `riptide-spring-boot-starter` and injecting it with `@Qualifier`
+- Routing a response on HTTP status series (`SUCCESSFUL`, `REDIRECTION`)
+- Extracting the `Location` header from a redirect response
+- Deserializing a JSON response body into a typed object
+
+## Running the tests
+
+```bash
+./mvnw test -pl riptide-example-basic -am
+```
+
+## Key classes
+
+| Class | Purpose |
+|---|---|
+| [`BasicRoutingExample`](src/main/java/org/zalando/riptide/example/basic/BasicRoutingExample.java) | Main example class – shows the `Http` API surface |
+| [`BasicRoutingExampleTest`](src/test/java/org/zalando/riptide/example/basic/BasicRoutingExampleTest.java) | JUnit 5 test – verifies redirect routing and body deserialization |
+
+## Key Riptide API entry points
+
+| Class | Purpose |
+|---|---|
+| [`Http`](../riptide-core/src/main/java/org/zalando/riptide/Http.java) | Entry point — call `.get()`, `.post()`, etc. to build requests |
+| [`Navigators`](../riptide-core/src/main/java/org/zalando/riptide/Navigators.java) | Factory for navigators: `series()`, `status()`, `contentType()`, etc. |
+| [`Bindings`](../riptide-core/src/main/java/org/zalando/riptide/Bindings.java) | Factory for route bindings: `on(SUCCESSFUL)`, `anySeries()`, etc. |
+
+## Dependencies used
+
+| Artifact | Why |
+|---|---|
+| `riptide-spring-boot-starter` | Starter-based `Http` client wiring and auto-configuration |
+| `spring-boot-starter-test` | Spring Boot test support for the runnable example |
+| `okhttp3:mockwebserver` | Mock HTTP server for tests |
+
+## How the test client is wired
+
+The test uses `@SpringBootTest` with `RiptideAutoConfiguration` and `JacksonAutoConfiguration`
+imported explicitly. The `base-url` for the `example` client is supplied dynamically via
+`@DynamicPropertySource` so it points to the local `MockWebServer` port chosen at runtime.
+The `Http` bean is then injected with `@Autowired @Qualifier("example")`.
+
+A `@Qualifier("example") HttpClientCustomizer` bean disables automatic redirect following so
+that `302 Found` responses remain visible to the routing callback — this keeps the
+`Location` header extraction example consistent with actual route behavior. In production you
+would typically let the HTTP client follow redirects automatically, or handle them explicitly
+in your routing tree if you need to inspect intermediate responses.

--- a/riptide-example-basic/pom.xml
+++ b/riptide-example-basic/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.zalando</groupId>
+        <artifactId>riptide-parent</artifactId>
+        <version>5.0.1-SNAPSHOT</version>
+        <relativePath>../riptide-parent</relativePath>
+    </parent>
+
+    <artifactId>riptide-example-basic</artifactId>
+
+    <name>Riptide: Example (Basic)</name>
+    <description>Basic onboarding example: Spring Boot starter path, request routing, header extraction, and body deserialization</description>
+
+    <dependencies>
+        <!-- Primary onboarding dependency: bring in riptide-core + autoconfigure via the starter -->
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>riptide-spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- Test infrastructure -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/riptide-example-basic/pom.xml
+++ b/riptide-example-basic/pom.xml
@@ -14,6 +14,11 @@
     <artifactId>riptide-example-basic</artifactId>
 
     <name>Riptide: Example (Basic)</name>
+
+    <properties>
+        <!-- Example modules are not published to Maven Central -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
     <description>Basic onboarding example: Spring Boot starter path, request routing, header extraction, and body deserialization</description>
 
     <dependencies>

--- a/riptide-example-basic/pom.xml
+++ b/riptide-example-basic/pom.xml
@@ -18,6 +18,8 @@
     <properties>
         <!-- Example modules are not published to Maven Central -->
         <maven.deploy.skip>true</maven.deploy.skip>
+        <!-- duplicate-finder fails on reactor builds because sibling target/classes don't exist at validate phase -->
+        <duplicate-finder.skip>true</duplicate-finder.skip>
     </properties>
     <description>Basic onboarding example: Spring Boot starter path, request routing, header extraction, and body deserialization</description>
 

--- a/riptide-example-basic/src/main/java/org/zalando/riptide/example/basic/BasicRoutingExample.java
+++ b/riptide-example-basic/src/main/java/org/zalando/riptide/example/basic/BasicRoutingExample.java
@@ -1,0 +1,85 @@
+package org.zalando.riptide.example.basic;
+
+import org.springframework.http.client.ClientHttpResponse;
+import org.zalando.riptide.Http;
+
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.springframework.http.HttpStatus.Series.REDIRECTION;
+import static org.springframework.http.HttpStatus.Series.SUCCESSFUL;
+import static org.zalando.riptide.Bindings.on;
+import static org.zalando.riptide.Navigators.series;
+
+/**
+ * Demonstrates Riptide's core response-routing API:
+ * <ul>
+ *   <li>Routing on HTTP status series ({@code SUCCESSFUL}, {@code REDIRECTION})</li>
+ *   <li>Extracting a {@code Location} header from a redirect response</li>
+ *   <li>Deserializing a typed JSON body from a successful response</li>
+ * </ul>
+ *
+ * <p>See {@code BasicRoutingExampleTest} for a runnable version wired through the
+ * Spring Boot starter path.
+ */
+public class BasicRoutingExample {
+
+    private final Http http;
+
+    public BasicRoutingExample(Http http) {
+        this.http = http;
+    }
+
+    /**
+     * Issues a GET request and captures the {@code Location} header when the server
+     * responds with a redirect (3xx).
+     *
+     * <p><strong>Note:</strong> only one route is registered ({@code REDIRECTION}). Any other
+     * response series (e.g. a {@code 200 OK} or a {@code 5xx}) will cause Riptide to throw an
+     * {@link org.zalando.riptide.UnexpectedResponseException} via the returned
+     * {@link java.util.concurrent.CompletableFuture}. In production, register an
+     * {@code anySeries()} fallback route or use
+     * {@link org.zalando.riptide.problem.ProblemRoute#problemHandling()} to avoid silent failures.
+     */
+    public URI followRedirect(String path) throws Exception {
+        AtomicReference<URI> location = new AtomicReference<>();
+
+        http.get(path)
+                .dispatch(series(),
+                        on(REDIRECTION).call((ClientHttpResponse response) ->
+                                location.set(response.getHeaders().getLocation())))
+                .join();
+
+        return location.get();
+    }
+
+    /**
+     * Issues a GET request and deserializes the JSON response body into an instance of
+     * {@code type} when the server responds with a success (2xx).
+     *
+     * <p><strong>Note:</strong> only one route is registered ({@code SUCCESSFUL}). Any other
+     * response series will cause Riptide to throw an
+     * {@link org.zalando.riptide.UnexpectedResponseException} via the returned
+     * {@link java.util.concurrent.CompletableFuture}. In production, register an
+     * {@code anySeries()} fallback route or use
+     * {@link org.zalando.riptide.problem.ProblemRoute#problemHandling()} to avoid silent failures.
+     */
+    public <T> T fetchBody(String path, Class<T> type) throws Exception {
+        AtomicReference<T> result = new AtomicReference<>();
+
+        http.get(path)
+                .dispatch(series(),
+                        on(SUCCESSFUL).call(type, result::set))
+                .join();
+
+        return result.get();
+    }
+
+    /**
+     * Returns the underlying {@link Http} client, useful for extending this example
+     * with additional routing patterns.
+     */
+    public Http getHttp() {
+        return http;
+    }
+}

--- a/riptide-example-basic/src/test/java/org/zalando/riptide/example/basic/BasicRoutingExampleTest.java
+++ b/riptide-example-basic/src/test/java/org/zalando/riptide/example/basic/BasicRoutingExampleTest.java
@@ -87,7 +87,7 @@ final class BasicRoutingExampleTest {
     private Http http;
 
     @Test
-    void should_capture_location_header_from_redirect_response() throws Exception {
+    void shouldCaptureLocationHeaderFromRedirectResponse() throws Exception {
         SERVER.enqueue(new MockResponse()
                 .setResponseCode(FOUND.value())
                 .setHeader(LOCATION, "/next"));
@@ -99,7 +99,7 @@ final class BasicRoutingExampleTest {
     }
 
     @Test
-    void should_deserialize_successful_json_response() throws Exception {
+    void shouldDeserializeSuccessfulJsonResponse() throws Exception {
         SERVER.enqueue(new MockResponse()
                 .setResponseCode(OK.value())
                 .setHeader(CONTENT_TYPE, "application/json")

--- a/riptide-example-basic/src/test/java/org/zalando/riptide/example/basic/BasicRoutingExampleTest.java
+++ b/riptide-example-basic/src/test/java/org/zalando/riptide/example/basic/BasicRoutingExampleTest.java
@@ -1,0 +1,116 @@
+package org.zalando.riptide.example.basic;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.zalando.riptide.Http;
+import org.zalando.riptide.autoconfigure.HttpClientCustomizer;
+import org.zalando.riptide.autoconfigure.RiptideAutoConfiguration;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.HttpStatus.FOUND;
+import static org.springframework.http.HttpStatus.OK;
+
+/**
+ * Runnable examples demonstrating Riptide's core response routing, wired via the
+ * Spring Boot starter ({@code riptide-spring-boot-starter}).
+ *
+ * <p>The HTTP client is configured with automatic redirect following <em>disabled</em>
+ * so that 3xx responses remain visible to the routing callback. This is intentional:
+ * it lets the example show how to inspect a {@code Location} header before deciding
+ * what to do next.
+ */
+@SpringBootTest(classes = BasicRoutingExampleTest.TestConfiguration.class, webEnvironment = NONE)
+final class BasicRoutingExampleTest {
+
+    /**
+     * Shared mock server for all tests. Started before the Spring context so that
+     * {@link #registerBaseUrl} can supply the base-url property to the auto-configuration.
+     */
+    static final MockWebServer SERVER = new MockWebServer();
+
+    @BeforeAll
+    static void startServer() throws IOException {
+        SERVER.start();
+    }
+
+    @AfterAll
+    static void stopServer() throws IOException {
+        SERVER.shutdown();
+    }
+
+    @DynamicPropertySource
+    static void registerBaseUrl(DynamicPropertyRegistry registry) {
+        registry.add("riptide.clients.example.base-url",
+                () -> String.format("http://%s:%d", SERVER.getHostName(), SERVER.getPort()));
+    }
+
+    /**
+     * Wires the Spring Boot auto-configuration and Jackson for this test context.
+     * The {@link HttpClientCustomizer} bean disables redirect following so that
+     * {@code 302} responses remain observable in the routing callback.
+     */
+    @Configuration
+    @ImportAutoConfiguration({
+            RiptideAutoConfiguration.class,
+            JacksonAutoConfiguration.class,
+    })
+    static class TestConfiguration {
+
+        @Bean
+        @Qualifier("example")
+        HttpClientCustomizer exampleHttpClientCustomizer() {
+            return builder -> ((HttpClientBuilder) builder).disableRedirectHandling();
+        }
+    }
+
+    @Autowired
+    @Qualifier("example")
+    private Http http;
+
+    @Test
+    void should_capture_location_header_from_redirect_response() throws Exception {
+        SERVER.enqueue(new MockResponse()
+                .setResponseCode(FOUND.value())
+                .setHeader(LOCATION, "/next"));
+
+        BasicRoutingExample example = new BasicRoutingExample(http);
+        URI location = example.followRedirect("/start");
+
+        assertThat(location).isEqualTo(URI.create("/next"));
+    }
+
+    @Test
+    void should_deserialize_successful_json_response() throws Exception {
+        SERVER.enqueue(new MockResponse()
+                .setResponseCode(OK.value())
+                .setHeader(CONTENT_TYPE, "application/json")
+                .setBody("{\"name\":\"Riptide\"}"));
+
+        BasicRoutingExample example = new BasicRoutingExample(http);
+        Greeting greeting = example.fetchBody("/greet", Greeting.class);
+
+        assertThat(greeting).isNotNull();
+        assertThat(greeting.name()).isEqualTo("Riptide");
+    }
+
+    record Greeting(String name) {}
+}


### PR DESCRIPTION
Adds riptide-example-basic: a runnable onboarding module demonstrating routing, redirect header extraction, and body deserialization via the Spring Boot starter path.
Enhances README.md with a Getting Started section; excludes the module from Maven Central. Fixes CI build failure where duplicate-finder-maven-plugin failed on reactor builds due to missing sibling target/classes at validate phase.
Closes #1031